### PR TITLE
feat: update referer database with chatbot/AI category

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A TypeScript-based referer parser library inspired by [nodejs-referer-parser](https://github.com/snowplow-referer-parser/nodejs-referer-parser). This library can be used in any JavaScript or TypeScript project, including various frameworks like React, Vue, Angular, or Node.js applications.
 
-The implementation uses the shared 'database' of known referers found in [file](https://s3-eu-west-1.amazonaws.com/snowplow-hosted-assets/third-party/referer-parser/referers-latest.json) as it says in the [snowplow-referer-parser/referer-parser](https://github.com/snowplow-referer-parser/referer-parser) README.
+The referer database is compiled from [snowplow-referer-parser](https://github.com/snowplow-referer-parser/referer-parser) and [Matomo's searchengine-and-social-list](https://github.com/matomo-org/searchengine-and-social-list), covering 450+ sources including AI chatbots, search engines, social networks, email providers, and paid advertising platforms.
 
 ## Installation
 
@@ -127,5 +127,6 @@ Note: While pnpm is the preferred package manager for this project, npm or yarn 
 
 ## Acknowledgements
 
-- [Snowplow](https://github.com/snowplow/referer-parser) for the original referer-parser
+- [Snowplow referer-parser](https://github.com/snowplow-referer-parser/referer-parser) for the referer database
+- [Matomo searchengine-and-social-list](https://github.com/matomo-org/searchengine-and-social-list) for additional AI assistant and social media data
 - [nodejs-referer-parser](https://github.com/snowplow-referer-parser/nodejs-referer-parser) for inspiration

--- a/README.md
+++ b/README.md
@@ -75,15 +75,16 @@ Note: In a server-side environment, the method to access the referer may vary de
 
 Parses the given referer URL and returns a `Referer` object containing:
 
-- `medium`: The type of referer (e.g., 'search', 'social', 'unknown', 'internal', 'direct', 'invalid')
-- `referer`: The name of the referer (e.g., 'google', 'facebook', 'twitter')
+- `medium`: The type of referer (e.g., 'search', 'social', 'chatbot', 'email', 'paid', 'unknown', 'internal', 'direct', 'invalid')
+- `referer`: The name of the referer (e.g., 'Google', 'Facebook', 'ChatGPT')
 - `term`: The search term used, if applicable (null otherwise)
 
 ## Features
 
-- Supports various search engines, social media platforms, and email providers
+- Supports 450+ sources across search engines, social media, email, paid ads, and AI chatbots
+- AI/chatbot detection: ChatGPT, Claude, Perplexity, Gemini, DeepSeek, Grok, Copilot, and more
 - Handles internal referrals
-- Typescript support
+- TypeScript support with full type inference
 
 ## Project Structure
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -190,4 +190,67 @@ describe('parse function', () => {
     let result = parse('/path', 'http://www.example.com');
     expect(result).toEqual({ medium: 'internal', referer: null, term: null });
   });
+
+  // Chatbot/AI referrers
+  it('should correctly parse ChatGPT referral', () => {
+    let result = parse('https://chatgpt.com/');
+    expect(result).toEqual({ medium: 'chatbot', referer: 'ChatGPT', term: null });
+  });
+
+  it('should correctly parse Claude referral', () => {
+    let result = parse('https://claude.ai/chat');
+    expect(result).toEqual({ medium: 'chatbot', referer: 'Claude.ai', term: null });
+  });
+
+  it('should correctly parse Perplexity referral', () => {
+    let result = parse('https://perplexity.ai/search?q=test');
+    expect(result).toEqual({ medium: 'chatbot', referer: 'Perplexity.ai', term: null });
+  });
+
+  it('should correctly parse Google Gemini referral', () => {
+    let result = parse('https://gemini.google.com/app');
+    expect(result).toEqual({ medium: 'chatbot', referer: 'Google Gemini', term: null });
+  });
+
+  it('should correctly parse DeepSeek referral', () => {
+    let result = parse('https://chat.deepseek.com/');
+    expect(result).toEqual({ medium: 'chatbot', referer: 'DeepSeek', term: null });
+  });
+
+  it('should correctly parse Grok referral', () => {
+    let result = parse('https://grok.com/');
+    expect(result).toEqual({ medium: 'chatbot', referer: 'Grok', term: null });
+  });
+
+  it('should correctly parse Microsoft Copilot referral', () => {
+    let result = parse('https://copilot.microsoft.com/');
+    expect(result).toEqual({ medium: 'chatbot', referer: 'Microsoft Copilot', term: null });
+  });
+
+  it('should correctly parse Phind referral', () => {
+    let result = parse('https://phind.com/search');
+    expect(result).toEqual({ medium: 'chatbot', referer: 'Phind', term: null });
+  });
+
+  // New/updated social referrers
+  it('should correctly parse Bluesky referral', () => {
+    let result = parse('https://go.bsky.app/abc');
+    expect(result).toEqual({ medium: 'social', referer: 'Bluesky', term: null });
+  });
+
+  it('should correctly parse Mastodon referral', () => {
+    let result = parse('https://mastodon.social/@user/123');
+    expect(result).toEqual({ medium: 'social', referer: 'Mastodon', term: null });
+  });
+
+  it('should correctly parse Threads referral', () => {
+    let result = parse('https://threads.net/@user');
+    expect(result).toEqual({ medium: 'social', referer: 'Threads', term: null });
+  });
+
+  // Brave search
+  it('should correctly parse Brave Search', () => {
+    let result = parse('https://search.brave.com/search?q=test');
+    expect(result).toEqual({ medium: 'search', referer: 'Brave', term: 'test' });
+  });
 });

--- a/src/utils/latest-referers.json
+++ b/src/utils/latest-referers.json
@@ -12,16 +12,6 @@
         "groups.google.co.uk"
       ]
     },
-    "Yandex Maps": {
-      "domains": [
-        "maps.yandex.ru",
-        "maps.yandex.ua",
-        "maps.yandex.com",
-        "maps.yandex.by",
-        "n.maps.yandex.ru"
-      ],
-      "parameters": ["text"]
-    },
     "Yahoo!": {
       "domains": [
         "finance.yahoo.com",
@@ -42,99 +32,633 @@
         "omg.yahoo.com",
         "match.yahoo.net"
       ]
+    },
+    "Yandex Maps": {
+      "parameters": ["text"],
+      "domains": [
+        "maps.yandex.ru",
+        "maps.yandex.ua",
+        "maps.yandex.com",
+        "maps.yandex.by",
+        "n.maps.yandex.ru"
+      ]
+    }
+  },
+  "email": {
+    "126 Mail": {
+      "domains": ["mail.126.com"]
+    },
+    "163 Mail": {
+      "domains": ["mail.163.com"]
+    },
+    "1und1": {
+      "domains": ["deref-1und1-02.de"]
+    },
+    "2degrees": {
+      "domains": ["webmail.2degreesbroadband.co.nz"]
+    },
+    "Adam Internet": {
+      "domains": ["webmail.adam.com.au"]
+    },
+    "AOL Mail": {
+      "domains": ["mail.aol.com"]
+    },
+    "Beeline": {
+      "domains": ["post.ru"]
+    },
+    "Bigpond": {
+      "domains": [
+        "webmail.bigpond.com",
+        "webmail2.bigpond.com",
+        "email.telstra.com",
+        "basic.messaging.bigpond.com"
+      ]
+    },
+    "Bluewin": {
+      "domains": ["rich-v01.bluewin.ch", "rich-v02.bluewin.ch", "email.bluewin.ch"]
+    },
+    "Commander": {
+      "domains": ["webmail.commander.net.au"]
+    },
+    "Daum Mail": {
+      "domains": ["mail2.daum.net", "mail.daum.net"]
+    },
+    "Dodo": {
+      "domains": ["webmail.dodo.com.au"]
+    },
+    "E1.ru": {
+      "domains": ["mail.e1.ru"]
+    },
+    "Freenet": {
+      "domains": ["webmail.freenet.de"]
+    },
+    "Gmail": {
+      "domains": ["mail.google.com", "inbox.google.com"]
+    },
+    "GMX": {
+      "domains": [
+        "deref-gmx.de",
+        "deref-gmx.at",
+        "deref-gmx.ch",
+        "deref-gmx.fr",
+        "deref-gmx.es",
+        "deref-gmx.it",
+        "deref-gmx.com",
+        "deref-gmx.net",
+        "deref-gmx.co.uk",
+        "lightmailer.gmx.de",
+        "lightmailer.gmx.at",
+        "lightmailer.gmx.ch",
+        "lightmailer.gmx.fr",
+        "lightmailer.gmx.es",
+        "lightmailer.gmx.it",
+        "lightmailer.gmx.com",
+        "lightmailer.gmx.net",
+        "lightmailer.gmx.co.uk",
+        "lightmailer-bs.gmx.net",
+        "lightmailer-bap.gmx.net"
+      ]
+    },
+    "iiNet": {
+      "domains": ["webmail.iinet.net.au", "mail.iinet.net.au"]
+    },
+    "Ionos": {
+      "domains": [
+        "email.ionos.de",
+        "email.ionos.es",
+        "email.ionos.fr",
+        "email.ionos.it",
+        "email.ionos.ca",
+        "email.ionos.mx",
+        "email.ionos.com",
+        "email.ionos.co.uk",
+        "mailbusiness.ionos.de",
+        "mailbusiness.ionos.es",
+        "mailbusiness.ionos.fr",
+        "mailbusiness.ionos.it",
+        "mailbusiness.ionos.ca",
+        "mailbusiness.ionos.mx",
+        "mailbusiness.ionos.com",
+        "mailbusiness.ionos.co.uk"
+      ]
+    },
+    "Inbox.com": {
+      "domains": ["inbox.com"]
+    },
+    "Infomaniak": {
+      "domains": ["mail.infomaniak.com"]
+    },
+    "iPrimus": {
+      "domains": ["webmail.iprimus.com.au"]
+    },
+    "Mail.ru": {
+      "domains": ["e.mail.ru", "touch.mail.ru"]
+    },
+    "Mail.com": {
+      "domains": ["deref-mail.com", "3c-lxa.mail.com", "lightmailer.mail.com"]
+    },
+    "Mastermail": {
+      "domains": ["mastermail.ru", "m.mastermail.ru"]
+    },
+    "Mynet Mail": {
+      "domains": ["mail.mynet.com"]
+    },
+    "Naver Mail": {
+      "domains": ["mail.naver.com"]
+    },
+    "Netspace": {
+      "domains": ["webmail.netspace.net.au"]
+    },
+    "Optus Zoo": {
+      "domains": ["webmail.optuszoo.com.au", "webmail.optusnet.com.au"]
+    },
+    "Orange Webmail": {
+      "domains": [
+        "orange.fr/webmail",
+        "mail01.orange.fr",
+        "mail02.orange.fr",
+        "wmail.orange.fr",
+        "messageriepro3.orange.fr",
+        "messagerie.orange.fr"
+      ]
+    },
+    "Outlook.com": {
+      "domains": ["mail.live.com", "outlook.live.com"]
+    },
+    "Proton": {
+      "domains": ["mail.proton.me"]
+    },
+    "QIP": {
+      "domains": ["mail.qip.ru"]
+    },
+    "QQ Mail": {
+      "domains": ["mail.qq.com", "exmail.qq.com"]
+    },
+    "Rambler": {
+      "domains": ["mail.rambler.ru"]
+    },
+    "Seznam Mail": {
+      "domains": ["email.seznam.cz"]
+    },
+    "Sibmail": {
+      "domains": ["sibmail.com"]
+    },
+    "T-online": {
+      "domains": ["email.t-online.de"]
+    },
+    "TIM": {
+      "domains": ["webmail.tim.it"]
+    },
+    "Ukr.net": {
+      "domains": ["mail.ukr.net"]
+    },
+    "UPC": {
+      "domains": ["upcmail.hispeed.ch"]
+    },
+    "Virgin": {
+      "domains": ["webmail.virginbroadband.com.au"]
+    },
+    "Vodafone": {
+      "domains": ["webmail.vodafone.co.nz", "mail.vodafone.de"]
+    },
+    "Westnet": {
+      "domains": ["webmail.westnet.com.au"]
+    },
+    "Web.de": {
+      "domains": [
+        "deref-web.de",
+        "3c.web.de",
+        "3c-bap.web.de",
+        "lightmailer-bap.web.de",
+        "lightmailer-bs.web.de"
+      ]
+    },
+    "Yandex": {
+      "domains": [
+        "mail.yandex.ru",
+        "mail.yandex.com",
+        "mail.yandex.kz",
+        "mail.yandex.ua",
+        "mail.yandex.by"
+      ]
+    },
+    "Yahoo! Mail": {
+      "domains": ["mail.yahoo.net", "mail.yahoo.com", "mail.yahoo.co.uk", "mail.yahoo.co.jp"]
+    },
+    "Zoho": {
+      "domains": ["mail.zoho.com"]
+    }
+  },
+  "social": {
+    "Facebook": {
+      "domains": [
+        "facebook.com",
+        "fb.me",
+        "m.facebook.com",
+        "l.facebook.com",
+        "lm.facebook.com",
+        "web.facebook.com",
+        "free.facebook.com"
+      ]
+    },
+    "Qzone": {
+      "domains": ["qzone.qq.com"]
+    },
+    "Habbo": {
+      "domains": ["habbo.com"]
+    },
+    "Twitter": {
+      "domains": ["twitter.com", "t.co", "x.com"]
+    },
+    "Bluesky": {
+      "domains": ["go.bsky.app", "bsky.app"]
+    },
+    "Lnk.Bio": {
+      "domains": ["lnk.bio"]
+    },
+    "Instagram": {
+      "domains": ["instagram.com", "l.instagram.com"]
+    },
+    "Threads": {
+      "domains": ["threads.com", "threads.net", "l.threads.net", "l.threads.com"]
+    },
+    "Youtube": {
+      "domains": ["youtube.com", "youtu.be"]
+    },
+    "Vimeo": {
+      "domains": ["vimeo.com"]
+    },
+    "Renren": {
+      "domains": ["renren.com"]
+    },
+    "Windows Live Spaces": {
+      "domains": ["login.live.com"]
+    },
+    "LinkedIn": {
+      "domains": ["linkedin.com", "lnkd.in"]
+    },
+    "Bebo": {
+      "domains": ["bebo.com"]
+    },
+    "Vkontakte": {
+      "domains": ["m.vk.com", "vk.com", "away.vk.com", "vkontakte.ru"]
+    },
+    "Tagged": {
+      "domains": ["login.tagged.com"]
+    },
+    "Orkut": {
+      "domains": ["orkut.com"]
+    },
+    "Myspace": {
+      "domains": ["myspace.com"]
+    },
+    "Friendster": {
+      "domains": ["friendster.com"]
+    },
+    "Badoo": {
+      "domains": ["badoo.com"]
+    },
+    "hi5": {
+      "domains": ["hi5.com"]
+    },
+    "Netlog": {
+      "domains": ["netlog.com"]
+    },
+    "Flixster": {
+      "domains": ["flixster.com"]
+    },
+    "MyLife": {
+      "domains": ["mylife.ru"]
+    },
+    "Paper.li": {
+      "domains": ["paper.li"]
+    },
+    "Classmates": {
+      "domains": ["classmates.com"]
+    },
+    "GitHub": {
+      "domains": ["github.com"]
+    },
+    "Google+": {
+      "domains": ["url.google.com", "plus.google.com"]
+    },
+    "Douban": {
+      "domains": ["douban.com"]
+    },
+    "Odnoklassniki": {
+      "domains": ["odnoklassniki.ru", "ok.ru"]
+    },
+    "Viadeo": {
+      "domains": ["viadeo.com"]
+    },
+    "Flickr": {
+      "domains": ["flickr.com"]
+    },
+    "WeeWorld": {
+      "domains": ["weeworld.com"]
+    },
+    "Last.fm": {
+      "domains": ["lastfm.ru"]
+    },
+    "MyHeritage": {
+      "domains": ["myheritage.com"]
+    },
+    "Xanga": {
+      "domains": ["xanga.com"]
+    },
+    "Mixi": {
+      "domains": ["mixi.jp"]
+    },
+    "Cyworld": {
+      "domains": ["global.cyworld.com"]
+    },
+    "Gaia Online": {
+      "domains": ["gaiaonline.com"]
+    },
+    "Skyrock": {
+      "domains": ["skyrock.com"]
+    },
+    "BlackPlanet": {
+      "domains": ["blackplanet.com"]
+    },
+    "myYearbook": {
+      "domains": ["myyearbook.com"]
+    },
+    "Fotolog": {
+      "domains": ["fotolog.com"]
+    },
+    "Friends Reunited": {
+      "domains": ["friendsreunited.com"]
+    },
+    "LiveJournal": {
+      "domains": ["livejournal.ru"]
+    },
+    "StudiVZ": {
+      "domains": ["studivz.net"]
+    },
+    "StackOverflow": {
+      "domains": ["stackoverflow.com"]
+    },
+    "Sonico.com": {
+      "domains": ["sonico.com"]
+    },
+    "Pinterest": {
+      "domains": [
+        "pinterest.ca",
+        "pinterest.cl",
+        "pinterest.co.kr",
+        "pinterest.com",
+        "pinterest.com.au",
+        "pinterest.co.uk",
+        "pinterest.de",
+        "pinterest.dk",
+        "pinterest.es",
+        "pinterest.fr",
+        "pinterest.jp",
+        "pinterest.nz",
+        "pinterest.pt",
+        "pinterest.se",
+        "pinterest.at",
+        "pinterest.ch",
+        "pinterest.com.mx",
+        "pinterest.ie",
+        "pinterest.it",
+        "pinterest.ph",
+        "pinterest.ru"
+      ]
+    },
+    "Plaxo": {
+      "domains": ["plaxo.com"]
+    },
+    "Geni": {
+      "domains": ["geni.com"]
+    },
+    "Tuenti": {
+      "domains": ["tuenti.com"]
+    },
+    "XING": {
+      "domains": ["xing.com"]
+    },
+    "Taringa!": {
+      "domains": ["taringa.net"]
+    },
+    "TikTok": {
+      "domains": ["tiktok.com", "vm.tiktok.com", "m.tiktok.com"]
+    },
+    "Tumblr": {
+      "domains": ["tumblr.com", "t.umblr.com"]
+    },
+    "Nasza-klasa.pl": {
+      "domains": ["nk.pl"]
+    },
+    "StumbleUpon": {
+      "domains": ["stumbleupon.com"]
+    },
+    "SourceForge": {
+      "domains": ["sourceforge.net"]
+    },
+    "Hyves": {
+      "domains": ["hyves.nl"]
+    },
+    "WAYN": {
+      "domains": ["wayn.com"]
+    },
+    "Buzznet": {
+      "domains": ["buzznet.com"]
+    },
+    "Multiply": {
+      "domains": ["multiply.com"]
+    },
+    "Foursquare": {
+      "domains": ["foursquare.com"]
+    },
+    "vKruguDruzei.ru": {
+      "domains": ["vkrugudruzei.ru"]
+    },
+    "Mail.ru": {
+      "domains": ["my.mail.ru"]
+    },
+    "MoiKrug.ru": {
+      "domains": ["moikrug.ru"]
+    },
+    "Reddit": {
+      "domains": [
+        "reddit.com",
+        "io.syncapps.lemmy_sync",
+        "old.reddit.com",
+        "np.reddit.com",
+        "www.reddit.com"
+      ]
+    },
+    "Tildes": {
+      "domains": ["tildes.net"]
+    },
+    "Hacker News": {
+      "domains": ["news.ycombinator.com", "io.github.hidroh.materialistic"]
+    },
+    "Identi.ca": {
+      "domains": ["identi.ca"]
+    },
+    "Weibo": {
+      "domains": ["weibo.com", "t.cn"]
+    },
+    "Delicious": {
+      "domains": ["delicious.com"]
+    },
+    "Pocket": {
+      "domains": ["getpocket.com"]
+    },
+    "ITU Sozluk": {
+      "domains": ["itusozluk.com"]
+    },
+    "Instela": {
+      "domains": ["instela.com"]
+    },
+    "Eksi Sozluk": {
+      "domains": ["Sozluk.com", "sourtimes.org"]
+    },
+    "Uludag Sozluk": {
+      "domains": ["uludagsozluk.com", "ulusozluk.com"]
+    },
+    "Inci Sozluk": {
+      "domains": ["inci.sozlukspot.com", "incisozluk.com", "incisozluk.cc"]
+    },
+    "Hocam.com": {
+      "domains": ["hocam.com"]
+    },
+    "Donanimhaber": {
+      "domains": ["donanimhaber.com"]
+    },
+    "Disqus": {
+      "domains": ["redirect.disqus.com", "disq.us", "disqus.com"]
+    },
+    "Quora": {
+      "domains": ["quora.com"]
+    },
+    "Skype": {
+      "domains": ["web.skype.com"]
+    },
+    "Slack": {
+      "domains": ["app.slack.com"]
+    },
+    "Snapchat": {
+      "domains": ["snapchat.com"]
+    },
+    "Telegram": {
+      "domains": [
+        "web.telegram.org",
+        "org.telegram.messenger",
+        "org.telegram.messenger.web",
+        "org.aka.messenger",
+        "org.telegram.biftogram",
+        "org.telegram.plus"
+      ]
+    },
+    "WhatsApp": {
+      "domains": ["web.whatsapp.com"]
+    },
+    "Whirlpool": {
+      "domains": ["forums.whirlpool.net.au"]
+    },
+    "Workplace": {
+      "domains": ["l.workplace.com", "lm.workplace.com"]
+    },
+    "Mastodon": {
+      "domains": [
+        "mastodon.social",
+        "mastodon.cloud",
+        "mastodon.online",
+        "mastodon.world",
+        "hachyderm.io",
+        "fosstodon.org",
+        "mstdn.io",
+        "mstdn.jp",
+        "mas.to",
+        "infosec.exchange",
+        "universeodon.com"
+      ]
+    },
+    "Discord": {
+      "domains": ["discord.com", "discordapp.com"]
     }
   },
   "search": {
-    "TalkTalk": {
-      "domains": ["www.talktalk.co.uk"],
-      "parameters": ["query"]
-    },
     "1.cz": {
-      "domains": ["1.cz"],
-      "parameters": ["q"]
+      "parameters": ["q"],
+      "domains": ["1.cz"]
     },
-    "Softonic": {
-      "domains": ["search.softonic.com"],
-      "parameters": ["q"]
+    "1&1": {
+      "parameters": ["q"],
+      "domains": ["search.1and1.com"]
     },
-    "GAIS": {
-      "domains": ["gais.cs.ccu.edu.tw"],
-      "parameters": ["q"]
-    },
-    "Freecause": {
-      "domains": ["search.freecause.com"],
-      "parameters": ["p"]
-    },
-    "360.cn": {
-      "domains": ["so.360.cn", "www.so.com"],
-      "parameters": ["q"]
-    },
-    "RPMFind": {
-      "domains": ["rpmfind.net", "fr2.rpmfind.net"],
-      "parameters": ["query"]
-    },
-    "Comcast": {
-      "domains": ["serach.comcast.net"],
-      "parameters": ["q"]
-    },
-    "Voila": {
-      "domains": ["search.ke.voila.fr", "www.lemoteur.fr"],
-      "parameters": ["rdata", "kw"]
-    },
-    "Nifty": {
-      "domains": ["search.nifty.com"],
-      "parameters": ["q"]
-    },
-    "Atlas": {
-      "domains": ["searchatlas.centrum.cz"],
-      "parameters": ["q"]
+    "1und1": {
+      "parameters": ["q"],
+      "domains": ["suche.1und1.de"]
     },
     "2gis": {
       "domains": ["2gis.ru", "www.2gis.ru", "link.2gis.ru", "www.link.2gis.ru"]
     },
-    "Lo.st": {
-      "domains": ["lo.st"],
-      "parameters": ["x_query"]
+    "360.cn": {
+      "parameters": ["q"],
+      "domains": ["so.360.cn", "www.so.com"]
     },
-    "DasTelefonbuch": {
-      "domains": ["www1.dastelefonbuch.de"],
-      "parameters": ["kw"]
-    },
-    "Fireball": {
-      "domains": ["www.fireball.de"],
-      "parameters": ["q"]
-    },
-    "1und1": {
-      "domains": ["search.1und1.de"],
-      "parameters": ["su"]
-    },
-    "Virgilio": {
+    "Abacho": {
+      "parameters": ["q"],
       "domains": [
-        "ricerca.virgilio.it",
-        "ricercaimmagini.virgilio.it",
-        "ricercavideo.virgilio.it",
-        "ricercanews.virgilio.it",
-        "mobile.virgilio.it"
-      ],
-      "parameters": ["qs"]
+        "www.abacho.de",
+        "www.abacho.com",
+        "www.abacho.co.uk",
+        "www.se.abacho.com",
+        "www.tr.abacho.com",
+        "www.abacho.at",
+        "www.abacho.fr",
+        "www.abacho.es",
+        "www.abacho.ch",
+        "www.abacho.it"
+      ]
     },
-    "Telstra": {
-      "domains": ["search.media.telstra.com.au"],
-      "parameters": ["find"]
+    "ABCsøk": {
+      "parameters": ["q"],
+      "domains": ["abcsolk.no", "verden.abcsok.no"]
     },
-    "Web.nl": {
-      "domains": ["www.web.nl"],
-      "parameters": ["zoekwoord"]
+    "Acoon": {
+      "parameters": ["begriff"],
+      "domains": ["www.acoon.de"]
     },
-    "Plazoo": {
-      "domains": ["www.plazoo.com"],
-      "parameters": ["q"]
+    "Alexa": {
+      "parameters": ["q"],
+      "domains": ["alexa.com", "search.toolbars.alexa.com"]
     },
-    "Goyellow.de": {
-      "domains": ["www.goyellow.de"],
-      "parameters": ["MDN"]
+    "Alice Adsl": {
+      "parameters": ["q"],
+      "domains": ["rechercher.aliceadsl.fr"]
+    },
+    "AllTheWeb": {
+      "parameters": ["q"],
+      "domains": ["www.alltheweb.com"]
+    },
+    "all.by": {
+      "parameters": ["query"],
+      "domains": ["all.by"]
+    },
+    "Altavista": {
+      "parameters": ["q"],
+      "domains": [
+        "www.altavista.com",
+        "search.altavista.com",
+        "listings.altavista.com",
+        "altavista.de",
+        "altavista.fr",
+        "be-nl.altavista.com",
+        "be-fr.altavista.com"
+      ]
+    },
+    "Amazon": {
+      "parameters": ["keywords"],
+      "domains": ["amazon.com", "www.amazon.com"]
     },
     "AOL": {
+      "parameters": ["q", "query"],
       "domains": [
         "search.aol.com",
         "search.aol.it",
@@ -162,2111 +686,38 @@
         "search.hp.my.aol.de",
         "search.hp.my.aol.it",
         "search-intl.netscape.com"
-      ],
-      "parameters": ["q", "query"]
-    },
-    "Acoon": {
-      "domains": ["www.acoon.de"],
-      "parameters": ["begriff"]
-    },
-    "Free": {
-      "domains": ["search.free.fr", "search1-2.free.fr", "search1-1.free.fr"],
-      "parameters": ["q"]
+      ]
     },
     "Apollo Latvia": {
-      "domains": ["apollo.lv/portal/search/"],
-      "parameters": ["q"]
-    },
-    "HighBeam": {
-      "domains": ["www.highbeam.com"],
-      "parameters": ["q"]
-    },
-    "I-play": {
-      "domains": ["start.iplay.com"],
-      "parameters": ["q"]
-    },
-    "FriendFeed": {
-      "domains": ["friendfeed.com"],
-      "parameters": ["q"]
-    },
-    "Yasni": {
-      "domains": [
-        "www.yasni.de",
-        "www.yasni.com",
-        "www.yasni.co.uk",
-        "www.yasni.ch",
-        "www.yasni.at"
-      ],
-      "parameters": ["query"]
-    },
-    "Gigablast": {
-      "domains": ["www.gigablast.com", "dir.gigablast.com"],
-      "parameters": ["q"]
-    },
-    "Arcor": {
-      "domains": ["www.arcor.de"],
-      "parameters": ["Keywords"]
-    },
-    "arama": {
-      "domains": ["arama.com"],
-      "parameters": ["q"]
-    },
-    "Fixsuche": {
-      "domains": ["www.fixsuche.de"],
-      "parameters": ["q"]
-    },
-    "Apontador": {
-      "domains": ["apontador.com.br", "www.apontador.com.br"],
-      "parameters": ["q"]
-    },
-    "Search.com": {
-      "domains": ["www.search.com"],
-      "parameters": ["q"]
-    },
-    "Monstercrawler": {
-      "domains": ["www.monstercrawler.com"],
-      "parameters": ["qry"]
-    },
-    "Google Images": {
-      "domains": [
-        "google.ac/imgres",
-        "google.ad/imgres",
-        "google.ae/imgres",
-        "google.am/imgres",
-        "google.as/imgres",
-        "google.at/imgres",
-        "google.az/imgres",
-        "google.ba/imgres",
-        "google.be/imgres",
-        "google.bf/imgres",
-        "google.bg/imgres",
-        "google.bi/imgres",
-        "google.bj/imgres",
-        "google.bs/imgres",
-        "google.by/imgres",
-        "google.ca/imgres",
-        "google.cat/imgres",
-        "google.cc/imgres",
-        "google.cd/imgres",
-        "google.cf/imgres",
-        "google.cg/imgres",
-        "google.ch/imgres",
-        "google.ci/imgres",
-        "google.cl/imgres",
-        "google.cm/imgres",
-        "google.cn/imgres",
-        "google.co.bw/imgres",
-        "google.co.ck/imgres",
-        "google.co.cr/imgres",
-        "google.co.id/imgres",
-        "google.co.il/imgres",
-        "google.co.in/imgres",
-        "google.co.jp/imgres",
-        "google.co.ke/imgres",
-        "google.co.kr/imgres",
-        "google.co.ls/imgres",
-        "google.co.ma/imgres",
-        "google.co.mz/imgres",
-        "google.co.nz/imgres",
-        "google.co.th/imgres",
-        "google.co.tz/imgres",
-        "google.co.ug/imgres",
-        "google.co.uk/imgres",
-        "google.co.uz/imgres",
-        "google.co.ve/imgres",
-        "google.co.vi/imgres",
-        "google.co.za/imgres",
-        "google.co.zm/imgres",
-        "google.co.zw/imgres",
-        "google.com/imgres",
-        "google.com.af/imgres",
-        "google.com.ag/imgres",
-        "google.com.ai/imgres",
-        "google.com.ar/imgres",
-        "google.com.au/imgres",
-        "google.com.bd/imgres",
-        "google.com.bh/imgres",
-        "google.com.bn/imgres",
-        "google.com.bo/imgres",
-        "google.com.br/imgres",
-        "google.com.by/imgres",
-        "google.com.bz/imgres",
-        "google.com.co/imgres",
-        "google.com.cu/imgres",
-        "google.com.cy/imgres",
-        "google.com.do/imgres",
-        "google.com.ec/imgres",
-        "google.com.eg/imgres",
-        "google.com.et/imgres",
-        "google.com.fj/imgres",
-        "google.com.gh/imgres",
-        "google.com.gi/imgres",
-        "google.com.gt/imgres",
-        "google.com.hk/imgres",
-        "google.com.jm/imgres",
-        "google.com.kh/imgres",
-        "google.com.kw/imgres",
-        "google.com.lb/imgres",
-        "google.com.lc/imgres",
-        "google.com.ly/imgres",
-        "google.com.mt/imgres",
-        "google.com.mx/imgres",
-        "google.com.my/imgres",
-        "google.com.na/imgres",
-        "google.com.nf/imgres",
-        "google.com.ng/imgres",
-        "google.com.ni/imgres",
-        "google.com.np/imgres",
-        "google.com.om/imgres",
-        "google.com.pa/imgres",
-        "google.com.pe/imgres",
-        "google.com.ph/imgres",
-        "google.com.pk/imgres",
-        "google.com.pr/imgres",
-        "google.com.py/imgres",
-        "google.com.qa/imgres",
-        "google.com.sa/imgres",
-        "google.com.sb/imgres",
-        "google.com.sg/imgres",
-        "google.com.sl/imgres",
-        "google.com.sv/imgres",
-        "google.com.tj/imgres",
-        "google.com.tn/imgres",
-        "google.com.tr/imgres",
-        "google.com.tw/imgres",
-        "google.com.ua/imgres",
-        "google.com.uy/imgres",
-        "google.com.vc/imgres",
-        "google.com.vn/imgres",
-        "google.cv/imgres",
-        "google.cz/imgres",
-        "google.de/imgres",
-        "google.dj/imgres",
-        "google.dk/imgres",
-        "google.dm/imgres",
-        "google.dz/imgres",
-        "google.ee/imgres",
-        "google.es/imgres",
-        "google.fi/imgres",
-        "google.fm/imgres",
-        "google.fr/imgres",
-        "google.ga/imgres",
-        "google.gd/imgres",
-        "google.ge/imgres",
-        "google.gf/imgres",
-        "google.gg/imgres",
-        "google.gl/imgres",
-        "google.gm/imgres",
-        "google.gp/imgres",
-        "google.gr/imgres",
-        "google.gy/imgres",
-        "google.hn/imgres",
-        "google.hr/imgres",
-        "google.ht/imgres",
-        "google.hu/imgres",
-        "google.ie/imgres",
-        "google.im/imgres",
-        "google.io/imgres",
-        "google.iq/imgres",
-        "google.is/imgres",
-        "google.it/imgres",
-        "google.it.ao/imgres",
-        "google.je/imgres",
-        "google.jo/imgres",
-        "google.kg/imgres",
-        "google.ki/imgres",
-        "google.kz/imgres",
-        "google.la/imgres",
-        "google.li/imgres",
-        "google.lk/imgres",
-        "google.lt/imgres",
-        "google.lu/imgres",
-        "google.lv/imgres",
-        "google.md/imgres",
-        "google.me/imgres",
-        "google.mg/imgres",
-        "google.mk/imgres",
-        "google.ml/imgres",
-        "google.mn/imgres",
-        "google.ms/imgres",
-        "google.mu/imgres",
-        "google.mv/imgres",
-        "google.mw/imgres",
-        "google.ne/imgres",
-        "google.nl/imgres",
-        "google.no/imgres",
-        "google.nr/imgres",
-        "google.nu/imgres",
-        "google.pl/imgres",
-        "google.pn/imgres",
-        "google.ps/imgres",
-        "google.pt/imgres",
-        "google.ro/imgres",
-        "google.rs/imgres",
-        "google.ru/imgres",
-        "google.rw/imgres",
-        "google.sc/imgres",
-        "google.se/imgres",
-        "google.sh/imgres",
-        "google.si/imgres",
-        "google.sk/imgres",
-        "google.sm/imgres",
-        "google.sn/imgres",
-        "google.so/imgres",
-        "google.st/imgres",
-        "google.td/imgres",
-        "google.tg/imgres",
-        "google.tk/imgres",
-        "google.tl/imgres",
-        "google.tm/imgres",
-        "google.to/imgres",
-        "google.tt/imgres",
-        "google.us/imgres",
-        "google.vg/imgres",
-        "google.vu/imgres",
-        "images.google.ws",
-        "images.google.ac",
-        "images.google.ad",
-        "images.google.ae",
-        "images.google.am",
-        "images.google.as",
-        "images.google.at",
-        "images.google.az",
-        "images.google.ba",
-        "images.google.be",
-        "images.google.bf",
-        "images.google.bg",
-        "images.google.bi",
-        "images.google.bj",
-        "images.google.bs",
-        "images.google.by",
-        "images.google.ca",
-        "images.google.cat",
-        "images.google.cc",
-        "images.google.cd",
-        "images.google.cf",
-        "images.google.cg",
-        "images.google.ch",
-        "images.google.ci",
-        "images.google.cl",
-        "images.google.cm",
-        "images.google.cn",
-        "images.google.co.bw",
-        "images.google.co.ck",
-        "images.google.co.cr",
-        "images.google.co.id",
-        "images.google.co.il",
-        "images.google.co.in",
-        "images.google.co.jp",
-        "images.google.co.ke",
-        "images.google.co.kr",
-        "images.google.co.ls",
-        "images.google.co.ma",
-        "images.google.co.mz",
-        "images.google.co.nz",
-        "images.google.co.th",
-        "images.google.co.tz",
-        "images.google.co.ug",
-        "images.google.co.uk",
-        "images.google.co.uz",
-        "images.google.co.ve",
-        "images.google.co.vi",
-        "images.google.co.za",
-        "images.google.co.zm",
-        "images.google.co.zw",
-        "images.google.com",
-        "images.google.com.af",
-        "images.google.com.ag",
-        "images.google.com.ai",
-        "images.google.com.ar",
-        "images.google.com.au",
-        "images.google.com.bd",
-        "images.google.com.bh",
-        "images.google.com.bn",
-        "images.google.com.bo",
-        "images.google.com.br",
-        "images.google.com.by",
-        "images.google.com.bz",
-        "images.google.com.co",
-        "images.google.com.cu",
-        "images.google.com.cy",
-        "images.google.com.do",
-        "images.google.com.ec",
-        "images.google.com.eg",
-        "images.google.com.et",
-        "images.google.com.fj",
-        "images.google.com.gh",
-        "images.google.com.gi",
-        "images.google.com.gt",
-        "images.google.com.hk",
-        "images.google.com.jm",
-        "images.google.com.kh",
-        "images.google.com.kw",
-        "images.google.com.lb",
-        "images.google.com.lc",
-        "images.google.com.ly",
-        "images.google.com.mt",
-        "images.google.com.mx",
-        "images.google.com.my",
-        "images.google.com.na",
-        "images.google.com.nf",
-        "images.google.com.ng",
-        "images.google.com.ni",
-        "images.google.com.np",
-        "images.google.com.om",
-        "images.google.com.pa",
-        "images.google.com.pe",
-        "images.google.com.ph",
-        "images.google.com.pk",
-        "images.google.com.pr",
-        "images.google.com.py",
-        "images.google.com.qa",
-        "images.google.com.sa",
-        "images.google.com.sb",
-        "images.google.com.sg",
-        "images.google.com.sl",
-        "images.google.com.sv",
-        "images.google.com.tj",
-        "images.google.com.tn",
-        "images.google.com.tr",
-        "images.google.com.tw",
-        "images.google.com.ua",
-        "images.google.com.uy",
-        "images.google.com.vc",
-        "images.google.com.vn",
-        "images.google.cv",
-        "images.google.cz",
-        "images.google.de",
-        "images.google.dj",
-        "images.google.dk",
-        "images.google.dm",
-        "images.google.dz",
-        "images.google.ee",
-        "images.google.es",
-        "images.google.fi",
-        "images.google.fm",
-        "images.google.fr",
-        "images.google.ga",
-        "images.google.gd",
-        "images.google.ge",
-        "images.google.gf",
-        "images.google.gg",
-        "images.google.gl",
-        "images.google.gm",
-        "images.google.gp",
-        "images.google.gr",
-        "images.google.gy",
-        "images.google.hn",
-        "images.google.hr",
-        "images.google.ht",
-        "images.google.hu",
-        "images.google.ie",
-        "images.google.im",
-        "images.google.io",
-        "images.google.iq",
-        "images.google.is",
-        "images.google.it",
-        "images.google.it.ao",
-        "images.google.je",
-        "images.google.jo",
-        "images.google.kg",
-        "images.google.ki",
-        "images.google.kz",
-        "images.google.la",
-        "images.google.li",
-        "images.google.lk",
-        "images.google.lt",
-        "images.google.lu",
-        "images.google.lv",
-        "images.google.md",
-        "images.google.me",
-        "images.google.mg",
-        "images.google.mk",
-        "images.google.ml",
-        "images.google.mn",
-        "images.google.ms",
-        "images.google.mu",
-        "images.google.mv",
-        "images.google.mw",
-        "images.google.ne",
-        "images.google.nl",
-        "images.google.no",
-        "images.google.nr",
-        "images.google.nu",
-        "images.google.pl",
-        "images.google.pn",
-        "images.google.ps",
-        "images.google.pt",
-        "images.google.ro",
-        "images.google.rs",
-        "images.google.ru",
-        "images.google.rw",
-        "images.google.sc",
-        "images.google.se",
-        "images.google.sh",
-        "images.google.si",
-        "images.google.sk",
-        "images.google.sm",
-        "images.google.sn",
-        "images.google.so",
-        "images.google.st",
-        "images.google.td",
-        "images.google.tg",
-        "images.google.tk",
-        "images.google.tl",
-        "images.google.tm",
-        "images.google.to",
-        "images.google.tt",
-        "images.google.us",
-        "images.google.vg",
-        "images.google.vu"
-      ],
-      "parameters": ["q"]
-    },
-    "ABCsøk": {
-      "domains": ["abcsolk.no", "verden.abcsok.no"],
-      "parameters": ["q"]
-    },
-    "Google Product Search": {
-      "domains": [
-        "google.ac/products",
-        "google.ad/products",
-        "google.ae/products",
-        "google.am/products",
-        "google.as/products",
-        "google.at/products",
-        "google.az/products",
-        "google.ba/products",
-        "google.be/products",
-        "google.bf/products",
-        "google.bg/products",
-        "google.bi/products",
-        "google.bj/products",
-        "google.bs/products",
-        "google.by/products",
-        "google.ca/products",
-        "google.cat/products",
-        "google.cc/products",
-        "google.cd/products",
-        "google.cf/products",
-        "google.cg/products",
-        "google.ch/products",
-        "google.ci/products",
-        "google.cl/products",
-        "google.cm/products",
-        "google.cn/products",
-        "google.co.bw/products",
-        "google.co.ck/products",
-        "google.co.cr/products",
-        "google.co.id/products",
-        "google.co.il/products",
-        "google.co.in/products",
-        "google.co.jp/products",
-        "google.co.ke/products",
-        "google.co.kr/products",
-        "google.co.ls/products",
-        "google.co.ma/products",
-        "google.co.mz/products",
-        "google.co.nz/products",
-        "google.co.th/products",
-        "google.co.tz/products",
-        "google.co.ug/products",
-        "google.co.uk/products",
-        "google.co.uz/products",
-        "google.co.ve/products",
-        "google.co.vi/products",
-        "google.co.za/products",
-        "google.co.zm/products",
-        "google.co.zw/products",
-        "google.com/products",
-        "google.com.af/products",
-        "google.com.ag/products",
-        "google.com.ai/products",
-        "google.com.ar/products",
-        "google.com.au/products",
-        "google.com.bd/products",
-        "google.com.bh/products",
-        "google.com.bn/products",
-        "google.com.bo/products",
-        "google.com.br/products",
-        "google.com.by/products",
-        "google.com.bz/products",
-        "google.com.co/products",
-        "google.com.cu/products",
-        "google.com.cy/products",
-        "google.com.do/products",
-        "google.com.ec/products",
-        "google.com.eg/products",
-        "google.com.et/products",
-        "google.com.fj/products",
-        "google.com.gh/products",
-        "google.com.gi/products",
-        "google.com.gt/products",
-        "google.com.hk/products",
-        "google.com.jm/products",
-        "google.com.kh/products",
-        "google.com.kw/products",
-        "google.com.lb/products",
-        "google.com.lc/products",
-        "google.com.ly/products",
-        "google.com.mt/products",
-        "google.com.mx/products",
-        "google.com.my/products",
-        "google.com.na/products",
-        "google.com.nf/products",
-        "google.com.ng/products",
-        "google.com.ni/products",
-        "google.com.np/products",
-        "google.com.om/products",
-        "google.com.pa/products",
-        "google.com.pe/products",
-        "google.com.ph/products",
-        "google.com.pk/products",
-        "google.com.pr/products",
-        "google.com.py/products",
-        "google.com.qa/products",
-        "google.com.sa/products",
-        "google.com.sb/products",
-        "google.com.sg/products",
-        "google.com.sl/products",
-        "google.com.sv/products",
-        "google.com.tj/products",
-        "google.com.tn/products",
-        "google.com.tr/products",
-        "google.com.tw/products",
-        "google.com.ua/products",
-        "google.com.uy/products",
-        "google.com.vc/products",
-        "google.com.vn/products",
-        "google.cv/products",
-        "google.cz/products",
-        "google.de/products",
-        "google.dj/products",
-        "google.dk/products",
-        "google.dm/products",
-        "google.dz/products",
-        "google.ee/products",
-        "google.es/products",
-        "google.fi/products",
-        "google.fm/products",
-        "google.fr/products",
-        "google.ga/products",
-        "google.gd/products",
-        "google.ge/products",
-        "google.gf/products",
-        "google.gg/products",
-        "google.gl/products",
-        "google.gm/products",
-        "google.gp/products",
-        "google.gr/products",
-        "google.gy/products",
-        "google.hn/products",
-        "google.hr/products",
-        "google.ht/products",
-        "google.hu/products",
-        "google.ie/products",
-        "google.im/products",
-        "google.io/products",
-        "google.iq/products",
-        "google.is/products",
-        "google.it/products",
-        "google.it.ao/products",
-        "google.je/products",
-        "google.jo/products",
-        "google.kg/products",
-        "google.ki/products",
-        "google.kz/products",
-        "google.la/products",
-        "google.li/products",
-        "google.lk/products",
-        "google.lt/products",
-        "google.lu/products",
-        "google.lv/products",
-        "google.md/products",
-        "google.me/products",
-        "google.mg/products",
-        "google.mk/products",
-        "google.ml/products",
-        "google.mn/products",
-        "google.ms/products",
-        "google.mu/products",
-        "google.mv/products",
-        "google.mw/products",
-        "google.ne/products",
-        "google.nl/products",
-        "google.no/products",
-        "google.nr/products",
-        "google.nu/products",
-        "google.pl/products",
-        "google.pn/products",
-        "google.ps/products",
-        "google.pt/products",
-        "google.ro/products",
-        "google.rs/products",
-        "google.ru/products",
-        "google.rw/products",
-        "google.sc/products",
-        "google.se/products",
-        "google.sh/products",
-        "google.si/products",
-        "google.sk/products",
-        "google.sm/products",
-        "google.sn/products",
-        "google.so/products",
-        "google.st/products",
-        "google.td/products",
-        "google.tg/products",
-        "google.tk/products",
-        "google.tl/products",
-        "google.tm/products",
-        "google.to/products",
-        "google.tt/products",
-        "google.us/products",
-        "google.vg/products",
-        "google.vu/products",
-        "google.ws/products",
-        "www.google.ac/products",
-        "www.google.ad/products",
-        "www.google.ae/products",
-        "www.google.am/products",
-        "www.google.as/products",
-        "www.google.at/products",
-        "www.google.az/products",
-        "www.google.ba/products",
-        "www.google.be/products",
-        "www.google.bf/products",
-        "www.google.bg/products",
-        "www.google.bi/products",
-        "www.google.bj/products",
-        "www.google.bs/products",
-        "www.google.by/products",
-        "www.google.ca/products",
-        "www.google.cat/products",
-        "www.google.cc/products",
-        "www.google.cd/products",
-        "www.google.cf/products",
-        "www.google.cg/products",
-        "www.google.ch/products",
-        "www.google.ci/products",
-        "www.google.cl/products",
-        "www.google.cm/products",
-        "www.google.cn/products",
-        "www.google.co.bw/products",
-        "www.google.co.ck/products",
-        "www.google.co.cr/products",
-        "www.google.co.id/products",
-        "www.google.co.il/products",
-        "www.google.co.in/products",
-        "www.google.co.jp/products",
-        "www.google.co.ke/products",
-        "www.google.co.kr/products",
-        "www.google.co.ls/products",
-        "www.google.co.ma/products",
-        "www.google.co.mz/products",
-        "www.google.co.nz/products",
-        "www.google.co.th/products",
-        "www.google.co.tz/products",
-        "www.google.co.ug/products",
-        "www.google.co.uk/products",
-        "www.google.co.uz/products",
-        "www.google.co.ve/products",
-        "www.google.co.vi/products",
-        "www.google.co.za/products",
-        "www.google.co.zm/products",
-        "www.google.co.zw/products",
-        "www.google.com/products",
-        "www.google.com.af/products",
-        "www.google.com.ag/products",
-        "www.google.com.ai/products",
-        "www.google.com.ar/products",
-        "www.google.com.au/products",
-        "www.google.com.bd/products",
-        "www.google.com.bh/products",
-        "www.google.com.bn/products",
-        "www.google.com.bo/products",
-        "www.google.com.br/products",
-        "www.google.com.by/products",
-        "www.google.com.bz/products",
-        "www.google.com.co/products",
-        "www.google.com.cu/products",
-        "www.google.com.cy/products",
-        "www.google.com.do/products",
-        "www.google.com.ec/products",
-        "www.google.com.eg/products",
-        "www.google.com.et/products",
-        "www.google.com.fj/products",
-        "www.google.com.gh/products",
-        "www.google.com.gi/products",
-        "www.google.com.gt/products",
-        "www.google.com.hk/products",
-        "www.google.com.jm/products",
-        "www.google.com.kh/products",
-        "www.google.com.kw/products",
-        "www.google.com.lb/products",
-        "www.google.com.lc/products",
-        "www.google.com.ly/products",
-        "www.google.com.mt/products",
-        "www.google.com.mx/products",
-        "www.google.com.my/products",
-        "www.google.com.na/products",
-        "www.google.com.nf/products",
-        "www.google.com.ng/products",
-        "www.google.com.ni/products",
-        "www.google.com.np/products",
-        "www.google.com.om/products",
-        "www.google.com.pa/products",
-        "www.google.com.pe/products",
-        "www.google.com.ph/products",
-        "www.google.com.pk/products",
-        "www.google.com.pr/products",
-        "www.google.com.py/products",
-        "www.google.com.qa/products",
-        "www.google.com.sa/products",
-        "www.google.com.sb/products",
-        "www.google.com.sg/products",
-        "www.google.com.sl/products",
-        "www.google.com.sv/products",
-        "www.google.com.tj/products",
-        "www.google.com.tn/products",
-        "www.google.com.tr/products",
-        "www.google.com.tw/products",
-        "www.google.com.ua/products",
-        "www.google.com.uy/products",
-        "www.google.com.vc/products",
-        "www.google.com.vn/products",
-        "www.google.cv/products",
-        "www.google.cz/products",
-        "www.google.de/products",
-        "www.google.dj/products",
-        "www.google.dk/products",
-        "www.google.dm/products",
-        "www.google.dz/products",
-        "www.google.ee/products",
-        "www.google.es/products",
-        "www.google.fi/products",
-        "www.google.fm/products",
-        "www.google.fr/products",
-        "www.google.ga/products",
-        "www.google.gd/products",
-        "www.google.ge/products",
-        "www.google.gf/products",
-        "www.google.gg/products",
-        "www.google.gl/products",
-        "www.google.gm/products",
-        "www.google.gp/products",
-        "www.google.gr/products",
-        "www.google.gy/products",
-        "www.google.hn/products",
-        "www.google.hr/products",
-        "www.google.ht/products",
-        "www.google.hu/products",
-        "www.google.ie/products",
-        "www.google.im/products",
-        "www.google.io/products",
-        "www.google.iq/products",
-        "www.google.is/products",
-        "www.google.it/products",
-        "www.google.it.ao/products",
-        "www.google.je/products",
-        "www.google.jo/products",
-        "www.google.kg/products",
-        "www.google.ki/products",
-        "www.google.kz/products",
-        "www.google.la/products",
-        "www.google.li/products",
-        "www.google.lk/products",
-        "www.google.lt/products",
-        "www.google.lu/products",
-        "www.google.lv/products",
-        "www.google.md/products",
-        "www.google.me/products",
-        "www.google.mg/products",
-        "www.google.mk/products",
-        "www.google.ml/products",
-        "www.google.mn/products",
-        "www.google.ms/products",
-        "www.google.mu/products",
-        "www.google.mv/products",
-        "www.google.mw/products",
-        "www.google.ne/products",
-        "www.google.nl/products",
-        "www.google.no/products",
-        "www.google.nr/products",
-        "www.google.nu/products",
-        "www.google.pl/products",
-        "www.google.pn/products",
-        "www.google.ps/products",
-        "www.google.pt/products",
-        "www.google.ro/products",
-        "www.google.rs/products",
-        "www.google.ru/products",
-        "www.google.rw/products",
-        "www.google.sc/products",
-        "www.google.se/products",
-        "www.google.sh/products",
-        "www.google.si/products",
-        "www.google.sk/products",
-        "www.google.sm/products",
-        "www.google.sn/products",
-        "www.google.so/products",
-        "www.google.st/products",
-        "www.google.td/products",
-        "www.google.tg/products",
-        "www.google.tk/products",
-        "www.google.tl/products",
-        "www.google.tm/products",
-        "www.google.to/products",
-        "www.google.tt/products",
-        "www.google.us/products",
-        "www.google.vg/products",
-        "www.google.vu/products",
-        "www.google.ws/products"
-      ],
-      "parameters": ["q"]
-    },
-    "DasOertliche": {
-      "domains": ["www.dasoertliche.de"],
-      "parameters": ["kw"]
-    },
-    "InfoSpace": {
-      "domains": [
-        "infospace.com",
-        "dogpile.com",
-        "www.dogpile.com",
-        "metacrawler.com",
-        "webfetch.com",
-        "webcrawler.com",
-        "search.kiwee.com",
-        "isearch.babylon.com",
-        "start.facemoods.com",
-        "search.magnetic.com",
-        "search.searchcompletion.com",
-        "clusty.com"
-      ],
-      "parameters": ["q", "s"]
-    },
-    "Weborama": {
-      "domains": ["www.weborama.com"],
-      "parameters": ["QUERY"]
-    },
-    "Bluewin": {
-      "domains": ["search.bluewin.ch"],
-      "parameters": ["searchTerm"]
-    },
-    "British Telecommunications": {
-      "domains": ["search.bt.com"],
-      "parameters": ["p"]
-    },
-    "Neti": {
-      "domains": ["www.neti.ee"],
-      "parameters": ["query"]
-    },
-    "Nigma": {
-      "domains": ["nigma.ru"],
-      "parameters": ["s"]
-    },
-    "Yahoo! Images": {
-      "domains": ["image.yahoo.cn", "images.search.yahoo.com"],
-      "parameters": ["p", "q"]
-    },
-    "Exalead": {
-      "domains": ["www.exalead.fr", "www.exalead.com"],
-      "parameters": ["q"]
-    },
-    "Teoma": {
-      "domains": ["www.teoma.com"],
-      "parameters": ["q"]
-    },
-    "Needtofind": {
-      "domains": ["ko.search.need2find.com"],
-      "parameters": ["searchfor"]
-    },
-    "Looksmart": {
-      "domains": ["www.looksmart.com"],
-      "parameters": ["key"]
-    },
-    "Flyingbird": {
-      "domains": ["inspsearch.com", "viview.inspsearch.com"],
-      "parameters": ["q"]
-    },
-    "Everyclick": {
-      "domains": ["www.everyclick.com"],
-      "parameters": ["keyword"]
-    },
-    "Wirtualna Polska": {
-      "domains": ["szukaj.wp.pl"],
-      "parameters": ["szukaj"]
-    },
-    "Toolbarhome": {
-      "domains": ["www.toolbarhome.com", "vshare.toolbarhome.com"],
-      "parameters": ["q"]
-    },
-    "Searchalot": {
-      "domains": ["searchalot.com"],
-      "parameters": ["q"]
-    },
-    "Yandex": {
-      "domains": [
-        "yandex.ru",
-        "yandex.ua",
-        "yandex.com",
-        "yandex.by",
-        "www.yandex.ru",
-        "www.yandex.ua",
-        "www.yandex.com",
-        "www.yandex.by",
-        "clck.yandex.ru",
-        "clck.yandex.ua",
-        "clck.yandex.com",
-        "clck.yandex.by"
-      ],
-      "parameters": ["text"]
-    },
-    "Indeed": {
-      "domains": [
-        "de.indeed.com",
-        "at.indeed.com",
-        "fr.indeed.com",
-        "it.indeed.com",
-        "ch.indeed.com",
-        "au.indeed.com"
-      ]
-    },
-    "canoe.ca": {
-      "domains": ["web.canoe.ca"],
-      "parameters": ["q"]
-    },
-    "Compuserve": {
-      "domains": ["websearch.cs.com"],
-      "parameters": ["query"]
-    },
-    "Blogdigger": {
-      "domains": ["www.blogdigger.com"],
-      "parameters": ["q"]
-    },
-    "Startpagina": {
-      "domains": ["startgoogle.startpagina.nl"],
-      "parameters": ["q"]
-    },
-    "eo": {
-      "domains": ["eo.st"],
-      "parameters": ["x_query"]
-    },
-    "Zhongsou": {
-      "domains": ["p.zhongsou.com"],
-      "parameters": ["w"]
-    },
-    "La Toile Du Quebec Via Google": {
-      "domains": ["www.toile.com", "web.toile.com"],
-      "parameters": ["q"]
-    },
-    "Paperball": {
-      "domains": ["www.paperball.de"],
-      "parameters": ["q"]
-    },
-    "StepStone": {
-      "domains": [
-        "www.stepstone.de",
-        "www.stepstone.at",
-        "www.stepstone.be",
-        "www.stepstone.fr",
-        "www.stepstone.nl",
-        "www.stepstone.dk",
-        "www.stepstone.se"
-      ]
-    },
-    "Jungle Spider": {
-      "domains": ["www.jungle-spider.de"],
-      "parameters": ["q"]
-    },
-    "PeoplePC": {
-      "domains": ["search.peoplepc.com"],
-      "parameters": ["q"]
-    },
-    "The Smart Search": {
-      "domains": ["thesmartsearch.net", "www.thesmartsearch.net"],
-      "parameters": ["q"]
-    },
-    "MetaCrawler.de": {
-      "domains": ["s1.metacrawler.de", "s2.metacrawler.de", "s3.metacrawler.de"],
-      "parameters": ["qry"]
-    },
-    "Orange": {
-      "domains": ["busca.orange.es", "search.orange.co.uk", "lemoteur.orange.fr"],
-      "parameters": ["q", "kw"]
-    },
-    "Gule Sider": {
-      "domains": ["www.gulesider.no"],
-      "parameters": ["q"]
-    },
-    "I.ua": {
-      "domains": ["search.i.ua"],
-      "parameters": ["q"]
-    },
-    "Francite": {
-      "domains": ["recherche.francite.com"],
-      "parameters": ["name"]
-    },
-    "Ask Toolbar": {
-      "domains": ["search.tb.ask.com"],
-      "parameters": ["searchfor"]
-    },
-    "Tut.by": {
-      "domains": ["search.tut.by"],
-      "parameters": ["query"]
-    },
-    "Trusted-Search": {
-      "domains": ["www.trusted--search.com"],
-      "parameters": ["w"]
-    },
-    "goo": {
-      "domains": ["search.goo.ne.jp", "ocnsearch.goo.ne.jp"],
-      "parameters": ["MT"]
-    },
-    "Fast Browser Search": {
-      "domains": ["www.fastbrowsersearch.com"],
-      "parameters": ["q"]
-    },
-    "kununu": {
-      "domains": ["kununu.com"],
-      "parameters": ["q"]
-    },
-    "Volny": {
-      "domains": ["web.volny.cz"],
-      "parameters": ["search"]
-    },
-    "Icerockeet": {
-      "domains": ["blogs.icerocket.com"],
-      "parameters": ["q"]
-    },
-    "Terra": {
-      "domains": ["buscador.terra.es", "buscador.terra.cl", "buscador.terra.com.br"],
-      "parameters": ["query"]
-    },
-    "Amazon": {
-      "domains": ["amazon.com", "www.amazon.com"],
-      "parameters": ["keywords"]
-    },
-    "Onet": {
-      "domains": ["szukaj.onet.pl"],
-      "parameters": ["qt"]
-    },
-    "Digg": {
-      "domains": ["digg.com"],
-      "parameters": ["s"]
-    },
-    "Abacho": {
-      "domains": [
-        "www.abacho.de",
-        "www.abacho.com",
-        "www.abacho.co.uk",
-        "www.se.abacho.com",
-        "www.tr.abacho.com",
-        "www.abacho.at",
-        "www.abacho.fr",
-        "www.abacho.es",
-        "www.abacho.ch",
-        "www.abacho.it"
-      ],
-      "parameters": ["q"]
-    },
-    "maailm": {
-      "domains": ["www.maailm.com"],
-      "parameters": ["tekst"]
-    },
-    "Flix": {
-      "domains": ["www.flix.de"],
-      "parameters": ["keyword"]
-    },
-    "Inbox.com": {
-      "domains": ["inbox.com/search/"],
-      "parameters": ["q"]
-    },
-    "Freenet": {
-      "domains": ["suche.freenet.de"],
-      "parameters": ["query", "Keywords"]
-    },
-    "Suchnase": {
-      "domains": ["www.suchnase.de"],
-      "parameters": ["q"]
-    },
-    "Dodo": {
-      "domains": ["google.dodo.com.au"],
-      "parameters": ["q"]
-    },
-    "Google Blogsearch": {
-      "domains": [
-        "blogsearch.google.ac",
-        "blogsearch.google.ad",
-        "blogsearch.google.ae",
-        "blogsearch.google.am",
-        "blogsearch.google.as",
-        "blogsearch.google.at",
-        "blogsearch.google.az",
-        "blogsearch.google.ba",
-        "blogsearch.google.be",
-        "blogsearch.google.bf",
-        "blogsearch.google.bg",
-        "blogsearch.google.bi",
-        "blogsearch.google.bj",
-        "blogsearch.google.bs",
-        "blogsearch.google.by",
-        "blogsearch.google.ca",
-        "blogsearch.google.cat",
-        "blogsearch.google.cc",
-        "blogsearch.google.cd",
-        "blogsearch.google.cf",
-        "blogsearch.google.cg",
-        "blogsearch.google.ch",
-        "blogsearch.google.ci",
-        "blogsearch.google.cl",
-        "blogsearch.google.cm",
-        "blogsearch.google.cn",
-        "blogsearch.google.co.bw",
-        "blogsearch.google.co.ck",
-        "blogsearch.google.co.cr",
-        "blogsearch.google.co.id",
-        "blogsearch.google.co.il",
-        "blogsearch.google.co.in",
-        "blogsearch.google.co.jp",
-        "blogsearch.google.co.ke",
-        "blogsearch.google.co.kr",
-        "blogsearch.google.co.ls",
-        "blogsearch.google.co.ma",
-        "blogsearch.google.co.mz",
-        "blogsearch.google.co.nz",
-        "blogsearch.google.co.th",
-        "blogsearch.google.co.tz",
-        "blogsearch.google.co.ug",
-        "blogsearch.google.co.uk",
-        "blogsearch.google.co.uz",
-        "blogsearch.google.co.ve",
-        "blogsearch.google.co.vi",
-        "blogsearch.google.co.za",
-        "blogsearch.google.co.zm",
-        "blogsearch.google.co.zw",
-        "blogsearch.google.com",
-        "blogsearch.google.com.af",
-        "blogsearch.google.com.ag",
-        "blogsearch.google.com.ai",
-        "blogsearch.google.com.ar",
-        "blogsearch.google.com.au",
-        "blogsearch.google.com.bd",
-        "blogsearch.google.com.bh",
-        "blogsearch.google.com.bn",
-        "blogsearch.google.com.bo",
-        "blogsearch.google.com.br",
-        "blogsearch.google.com.by",
-        "blogsearch.google.com.bz",
-        "blogsearch.google.com.co",
-        "blogsearch.google.com.cu",
-        "blogsearch.google.com.cy",
-        "blogsearch.google.com.do",
-        "blogsearch.google.com.ec",
-        "blogsearch.google.com.eg",
-        "blogsearch.google.com.et",
-        "blogsearch.google.com.fj",
-        "blogsearch.google.com.gh",
-        "blogsearch.google.com.gi",
-        "blogsearch.google.com.gt",
-        "blogsearch.google.com.hk",
-        "blogsearch.google.com.jm",
-        "blogsearch.google.com.kh",
-        "blogsearch.google.com.kw",
-        "blogsearch.google.com.lb",
-        "blogsearch.google.com.lc",
-        "blogsearch.google.com.ly",
-        "blogsearch.google.com.mt",
-        "blogsearch.google.com.mx",
-        "blogsearch.google.com.my",
-        "blogsearch.google.com.na",
-        "blogsearch.google.com.nf",
-        "blogsearch.google.com.ng",
-        "blogsearch.google.com.ni",
-        "blogsearch.google.com.np",
-        "blogsearch.google.com.om",
-        "blogsearch.google.com.pa",
-        "blogsearch.google.com.pe",
-        "blogsearch.google.com.ph",
-        "blogsearch.google.com.pk",
-        "blogsearch.google.com.pr",
-        "blogsearch.google.com.py",
-        "blogsearch.google.com.qa",
-        "blogsearch.google.com.sa",
-        "blogsearch.google.com.sb",
-        "blogsearch.google.com.sg",
-        "blogsearch.google.com.sl",
-        "blogsearch.google.com.sv",
-        "blogsearch.google.com.tj",
-        "blogsearch.google.com.tn",
-        "blogsearch.google.com.tr",
-        "blogsearch.google.com.tw",
-        "blogsearch.google.com.ua",
-        "blogsearch.google.com.uy",
-        "blogsearch.google.com.vc",
-        "blogsearch.google.com.vn",
-        "blogsearch.google.cv",
-        "blogsearch.google.cz",
-        "blogsearch.google.de",
-        "blogsearch.google.dj",
-        "blogsearch.google.dk",
-        "blogsearch.google.dm",
-        "blogsearch.google.dz",
-        "blogsearch.google.ee",
-        "blogsearch.google.es",
-        "blogsearch.google.fi",
-        "blogsearch.google.fm",
-        "blogsearch.google.fr",
-        "blogsearch.google.ga",
-        "blogsearch.google.gd",
-        "blogsearch.google.ge",
-        "blogsearch.google.gf",
-        "blogsearch.google.gg",
-        "blogsearch.google.gl",
-        "blogsearch.google.gm",
-        "blogsearch.google.gp",
-        "blogsearch.google.gr",
-        "blogsearch.google.gy",
-        "blogsearch.google.hn",
-        "blogsearch.google.hr",
-        "blogsearch.google.ht",
-        "blogsearch.google.hu",
-        "blogsearch.google.ie",
-        "blogsearch.google.im",
-        "blogsearch.google.io",
-        "blogsearch.google.iq",
-        "blogsearch.google.is",
-        "blogsearch.google.it",
-        "blogsearch.google.it.ao",
-        "blogsearch.google.je",
-        "blogsearch.google.jo",
-        "blogsearch.google.kg",
-        "blogsearch.google.ki",
-        "blogsearch.google.kz",
-        "blogsearch.google.la",
-        "blogsearch.google.li",
-        "blogsearch.google.lk",
-        "blogsearch.google.lt",
-        "blogsearch.google.lu",
-        "blogsearch.google.lv",
-        "blogsearch.google.md",
-        "blogsearch.google.me",
-        "blogsearch.google.mg",
-        "blogsearch.google.mk",
-        "blogsearch.google.ml",
-        "blogsearch.google.mn",
-        "blogsearch.google.ms",
-        "blogsearch.google.mu",
-        "blogsearch.google.mv",
-        "blogsearch.google.mw",
-        "blogsearch.google.ne",
-        "blogsearch.google.nl",
-        "blogsearch.google.no",
-        "blogsearch.google.nr",
-        "blogsearch.google.nu",
-        "blogsearch.google.pl",
-        "blogsearch.google.pn",
-        "blogsearch.google.ps",
-        "blogsearch.google.pt",
-        "blogsearch.google.ro",
-        "blogsearch.google.rs",
-        "blogsearch.google.ru",
-        "blogsearch.google.rw",
-        "blogsearch.google.sc",
-        "blogsearch.google.se",
-        "blogsearch.google.sh",
-        "blogsearch.google.si",
-        "blogsearch.google.sk",
-        "blogsearch.google.sm",
-        "blogsearch.google.sn",
-        "blogsearch.google.so",
-        "blogsearch.google.st",
-        "blogsearch.google.td",
-        "blogsearch.google.tg",
-        "blogsearch.google.tk",
-        "blogsearch.google.tl",
-        "blogsearch.google.tm",
-        "blogsearch.google.to",
-        "blogsearch.google.tt",
-        "blogsearch.google.us",
-        "blogsearch.google.vg",
-        "blogsearch.google.vu",
-        "blogsearch.google.ws"
-      ],
-      "parameters": ["q"]
-    },
-    "Poisk.ru": {
-      "domains": ["poisk.ru"],
-      "parameters": ["q"]
-    },
-    "Sharelook": {
-      "domains": ["www.sharelook.fr"],
-      "parameters": ["keyword"]
-    },
-    "Finderoo": {
-      "domains": ["www.finderoo.com"],
-      "parameters": ["q"]
-    },
-    "Najdi": {
-      "domains": ["www.najdi.si"],
-      "parameters": ["q"]
-    },
-    "Picsearch": {
-      "domains": ["www.picsearch.com"],
-      "parameters": ["q"]
-    },
-    "Mail.ru": {
-      "domains": ["mail.ru", "m.mail.ru", "go.mail.ru"],
-      "parameters": ["q"]
-    },
-    "Alexa": {
-      "domains": ["alexa.com", "search.toolbars.alexa.com"],
-      "parameters": ["q"]
-    },
-    "Metager": {
-      "domains": ["meta.rrzn.uni-hannover.de", "www.metager.de"],
-      "parameters": ["eingabe"]
-    },
-    "Technorati": {
-      "domains": ["technorati.com"],
-      "parameters": ["q"]
-    },
-    "Globososo": {
-      "domains": ["searches.globososo.com", "search.globososo.com"],
-      "parameters": ["q"]
-    },
-    "WWW": {
-      "domains": ["search.www.ee"],
-      "parameters": ["query"]
-    },
-    "Trouvez.com": {
-      "domains": ["www.trouvez.com"],
-      "parameters": ["query"]
-    },
-    "IXquick": {
-      "domains": [
-        "ixquick.com",
-        "www.eu.ixquick.com",
-        "ixquick.de",
-        "www.ixquick.de",
-        "us.ixquick.com",
-        "s1.us.ixquick.com",
-        "s2.us.ixquick.com",
-        "s3.us.ixquick.com",
-        "s4.us.ixquick.com",
-        "s5.us.ixquick.com",
-        "eu.ixquick.com",
-        "s8-eu.ixquick.com",
-        "s1-eu.ixquick.de"
-      ],
-      "parameters": ["query"]
-    },
-    "Naver Images": {
-      "domains": ["image.search.naver.com", "imagesearch.naver.com"],
-      "parameters": ["query"]
-    },
-    "Zapmeta": {
-      "domains": ["www.zapmeta.com", "www.zapmeta.nl", "www.zapmeta.de", "uk.zapmeta.com"],
-      "parameters": ["q", "query"]
-    },
-    "Yippy": {
-      "domains": ["search.yippy.com"],
-      "parameters": ["q", "query"]
-    },
-    "Clix": {
-      "domains": ["pesquisa.clix.pt"],
-      "parameters": ["question"]
-    },
-    "Walhello": {
-      "domains": ["www.walhello.info", "www.walhello.com", "www.walhello.de", "www.walhello.nl"],
-      "parameters": ["key"]
-    },
-    "Meta": {
-      "domains": ["meta.ua"],
-      "parameters": ["q"]
-    },
-    "Skynet": {
-      "domains": ["www.skynet.be"],
-      "parameters": ["q"]
-    },
-    "Searchy": {
-      "domains": ["www.searchy.co.uk"],
-      "parameters": ["q"]
-    },
-    "Findwide": {
-      "domains": ["search.findwide.com"],
-      "parameters": ["k"]
-    },
-    "WebSearch": {
-      "domains": ["www.websearch.com"],
-      "parameters": ["qkw", "q"]
-    },
-    "Rambler": {
-      "domains": ["nova.rambler.ru"],
-      "parameters": ["query", "words"]
-    },
-    "Latne": {
-      "domains": ["www.latne.lv"],
-      "parameters": ["q"]
-    },
-    "MySearch": {
-      "domains": [
-        "mysearch.com",
-        "www.mysearch.com",
-        "ms114.mysearch.com",
-        "ms146.mysearch.com",
-        "kf.mysearch.myway.com",
-        "ki.mysearch.myway.com",
-        "search.myway.com",
-        "search.mywebsearch.com"
-      ],
-      "parameters": ["searchfor", "searchFor"]
-    },
-    "Cuil": {
-      "domains": ["www.cuil.com"],
-      "parameters": ["q"]
-    },
-    "Tixuma": {
-      "domains": ["www.tixuma.de"],
-      "parameters": ["sc"]
-    },
-    "Sapo": {
-      "domains": ["pesquisa.sapo.pt"],
-      "parameters": ["q"]
-    },
-    "Gnadenmeer": {
-      "domains": ["www.gnadenmeer.de"],
-      "parameters": ["keyword"]
-    },
-    "Lilo": {
-      "domains": ["search.lilo.org"],
-      "parameters": ["q"]
-    },
-    "Naver": {
-      "domains": ["search.naver.com"],
-      "parameters": ["query"]
-    },
-    "Zoeken": {
-      "domains": ["www.zoeken.nl"],
-      "parameters": ["q"]
-    },
-    "Startsiden": {
-      "domains": ["www.startsiden.no"],
-      "parameters": ["q"]
-    },
-    "Yam": {
-      "domains": ["search.yam.com"],
-      "parameters": ["k"]
-    },
-    "Eniro": {
-      "domains": ["www.eniro.se"],
-      "parameters": ["q", "search_word"]
+      "parameters": ["q"],
+      "domains": ["apollo.lv/portal/search/"]
     },
     "APOLL07": {
-      "domains": ["apollo7.de"],
-      "parameters": ["query"]
-    },
-    "Biglobe": {
-      "domains": ["cgi.search.biglobe.ne.jp"],
-      "parameters": ["q"]
-    },
-    "Mozbot": {
-      "domains": ["www.mozbot.fr", "www.mozbot.co.uk", "www.mozbot.com"],
-      "parameters": ["q"]
-    },
-    "ICQ": {
-      "domains": ["www.icq.com", "search.icq.com"],
-      "parameters": ["q"]
-    },
-    "Baidu": {
-      "domains": [
-        "www.baidu.com",
-        "www1.baidu.com",
-        "zhidao.baidu.com",
-        "tieba.baidu.com",
-        "news.baidu.com",
-        "web.gougou.com",
-        "m.baidu.com"
-      ],
-      "parameters": ["wd", "word", "kw", "k"]
-    },
-    "Conduit": {
-      "domains": ["search.conduit.com"],
-      "parameters": ["q"]
-    },
-    "Vindex": {
-      "domains": ["www.vindex.nl", "search.vindex.nl"],
-      "parameters": ["search_for"]
-    },
-    "Babylon": {
-      "domains": ["search.babylon.com", "searchassist.babylon.com"],
-      "parameters": ["q"]
-    },
-    "TrovaRapido": {
-      "domains": ["www.trovarapido.com"],
-      "parameters": ["q"]
-    },
-    "Winamp": {
-      "domains": ["search.winamp.com"],
-      "parameters": ["q"]
-    },
-    "Suchmaschine.com": {
-      "domains": ["www.suchmaschine.com"],
-      "parameters": ["suchstr"]
-    },
-    "Lycos": {
-      "domains": ["search.lycos.com", "www.lycos.com", "lycos.com"],
-      "parameters": ["query"]
-    },
-    "Vinden": {
-      "domains": ["www.vinden.nl"],
-      "parameters": ["q"]
-    },
-    "Altavista": {
-      "domains": [
-        "www.altavista.com",
-        "search.altavista.com",
-        "listings.altavista.com",
-        "altavista.de",
-        "altavista.fr",
-        "be-nl.altavista.com",
-        "be-fr.altavista.com"
-      ],
-      "parameters": ["q"]
-    },
-    "dmoz": {
-      "domains": ["dmoz.org", "editors.dmoz.org"],
-      "parameters": ["q"]
-    },
-    "Ecosia": {
-      "domains": ["ecosia.org"],
-      "parameters": ["q"]
-    },
-    "Maxwebsearch": {
-      "domains": ["maxwebsearch.com"],
-      "parameters": ["query"]
-    },
-    "Euroseek": {
-      "domains": ["www.euroseek.com"],
-      "parameters": ["string"]
-    },
-    "Qwant": {
-      "domains": ["www.qwant.com", "lite.qwant.com"],
-      "parameters": ["q"]
-    },
-    "X-recherche": {
-      "domains": ["www.x-recherche.com"],
-      "parameters": ["MOTS"]
-    },
-    "Yandex Images": {
-      "domains": ["images.yandex.ru", "images.yandex.ua", "images.yandex.com", "images.yandex.by"],
-      "parameters": ["text"]
-    },
-    "GMX": {
-      "domains": ["suche.gmx.net"],
-      "parameters": ["su"]
-    },
-    "Daemon search": {
-      "domains": ["daemon-search.com", "my.daemon-search.com"],
-      "parameters": ["q"]
-    },
-    "Shenma": {
-      "domains": [
-        "so.m.sm.cn",
-        "yz.m.sm.cn",
-        "m.sm.cn",
-        "quark.sm.cn",
-        "m.sp.sm.cn",
-        "m.yz2.sm.cn",
-        "m.yz.sm.cn"
-      ],
-      "parameters": ["q"]
-    },
-    "Firstfind": {
-      "domains": ["www.firstsfind.com"],
-      "parameters": ["qry"]
-    },
-    "Crawler": {
-      "domains": ["www.crawler.com"],
-      "parameters": ["q"]
-    },
-    "Holmes": {
-      "domains": ["holmes.ge"],
-      "parameters": ["q"]
-    },
-    "Charter": {
-      "domains": ["www.charter.net"],
-      "parameters": ["q"]
-    },
-    "Ilse": {
-      "domains": ["www.ilse.nl"],
-      "parameters": ["search_for"]
-    },
-    "earthlink": {
-      "domains": ["search.earthlink.net"],
-      "parameters": ["q"]
-    },
-    "Qualigo": {
-      "domains": ["www.qualigo.at", "www.qualigo.ch", "www.qualigo.de", "www.qualigo.nl"],
-      "parameters": ["q"]
-    },
-    "El Mundo": {
-      "domains": ["ariadna.elmundo.es"],
-      "parameters": ["q"]
-    },
-    "Metager2": {
-      "domains": ["metager2.de"],
-      "parameters": ["q"]
-    },
-    "Forestle": {
-      "domains": ["forestle.org", "www.forestle.org", "forestle.mobi"],
-      "parameters": ["q"]
-    },
-    "Search.ch": {
-      "domains": ["www.search.ch"],
-      "parameters": ["q"]
-    },
-    "Liveinternet": {
-      "domains": ["liveinternet.ru"],
-      "parameters": ["q"]
-    },
-    "Meinestadt": {
-      "domains": ["www.meinestadt.de"],
-      "parameters": ["words"]
-    },
-    "Freshweather": {
-      "domains": ["www.fresh-weather.com"],
-      "parameters": ["q"]
-    },
-    "AllTheWeb": {
-      "domains": ["www.alltheweb.com"],
-      "parameters": ["q"]
-    },
-    "Coccoc": {
-      "domains": ["coccoc.com"],
-      "parameters": ["q"]
-    },
-    "Snapdo": {
-      "domains": ["search.snapdo.com"],
-      "parameters": ["q"]
-    },
-    "UKR.net": {
-      "domains": ["search.ukr.net"],
-      "parameters": ["q"]
-    },
-    "Zoek": {
-      "domains": ["www3.zoek.nl"],
-      "parameters": ["q"]
-    },
-    "Daum": {
-      "domains": ["search.daum.net"],
-      "parameters": ["q"]
-    },
-    "Marktplaats": {
-      "domains": ["www.marktplaats.nl"],
-      "parameters": ["query"]
-    },
-    "suche.info": {
-      "domains": ["suche.info"],
-      "parameters": ["q"]
-    },
-    "Google News": {
-      "domains": [
-        "news.google.ac",
-        "news.google.ad",
-        "news.google.ae",
-        "news.google.am",
-        "news.google.as",
-        "news.google.at",
-        "news.google.az",
-        "news.google.ba",
-        "news.google.be",
-        "news.google.bf",
-        "news.google.bg",
-        "news.google.bi",
-        "news.google.bj",
-        "news.google.bs",
-        "news.google.by",
-        "news.google.ca",
-        "news.google.cat",
-        "news.google.cc",
-        "news.google.cd",
-        "news.google.cf",
-        "news.google.cg",
-        "news.google.ch",
-        "news.google.ci",
-        "news.google.cl",
-        "news.google.cm",
-        "news.google.cn",
-        "news.google.co.bw",
-        "news.google.co.ck",
-        "news.google.co.cr",
-        "news.google.co.id",
-        "news.google.co.il",
-        "news.google.co.in",
-        "news.google.co.jp",
-        "news.google.co.ke",
-        "news.google.co.kr",
-        "news.google.co.ls",
-        "news.google.co.ma",
-        "news.google.co.mz",
-        "news.google.co.nz",
-        "news.google.co.th",
-        "news.google.co.tz",
-        "news.google.co.ug",
-        "news.google.co.uk",
-        "news.google.co.uz",
-        "news.google.co.ve",
-        "news.google.co.vi",
-        "news.google.co.za",
-        "news.google.co.zm",
-        "news.google.co.zw",
-        "news.google.com",
-        "news.google.com.af",
-        "news.google.com.ag",
-        "news.google.com.ai",
-        "news.google.com.ar",
-        "news.google.com.au",
-        "news.google.com.bd",
-        "news.google.com.bh",
-        "news.google.com.bn",
-        "news.google.com.bo",
-        "news.google.com.br",
-        "news.google.com.by",
-        "news.google.com.bz",
-        "news.google.com.co",
-        "news.google.com.cu",
-        "news.google.com.cy",
-        "news.google.com.do",
-        "news.google.com.ec",
-        "news.google.com.eg",
-        "news.google.com.et",
-        "news.google.com.fj",
-        "news.google.com.gh",
-        "news.google.com.gi",
-        "news.google.com.gt",
-        "news.google.com.hk",
-        "news.google.com.jm",
-        "news.google.com.kh",
-        "news.google.com.kw",
-        "news.google.com.lb",
-        "news.google.com.lc",
-        "news.google.com.ly",
-        "news.google.com.mt",
-        "news.google.com.mx",
-        "news.google.com.my",
-        "news.google.com.na",
-        "news.google.com.nf",
-        "news.google.com.ng",
-        "news.google.com.ni",
-        "news.google.com.np",
-        "news.google.com.om",
-        "news.google.com.pa",
-        "news.google.com.pe",
-        "news.google.com.ph",
-        "news.google.com.pk",
-        "news.google.com.pr",
-        "news.google.com.py",
-        "news.google.com.qa",
-        "news.google.com.sa",
-        "news.google.com.sb",
-        "news.google.com.sg",
-        "news.google.com.sl",
-        "news.google.com.sv",
-        "news.google.com.tj",
-        "news.google.com.tn",
-        "news.google.com.tr",
-        "news.google.com.tw",
-        "news.google.com.ua",
-        "news.google.com.uy",
-        "news.google.com.vc",
-        "news.google.com.vn",
-        "news.google.cv",
-        "news.google.cz",
-        "news.google.de",
-        "news.google.dj",
-        "news.google.dk",
-        "news.google.dm",
-        "news.google.dz",
-        "news.google.ee",
-        "news.google.es",
-        "news.google.fi",
-        "news.google.fm",
-        "news.google.fr",
-        "news.google.ga",
-        "news.google.gd",
-        "news.google.ge",
-        "news.google.gf",
-        "news.google.gg",
-        "news.google.gl",
-        "news.google.gm",
-        "news.google.gp",
-        "news.google.gr",
-        "news.google.gy",
-        "news.google.hn",
-        "news.google.hr",
-        "news.google.ht",
-        "news.google.hu",
-        "news.google.ie",
-        "news.google.im",
-        "news.google.io",
-        "news.google.iq",
-        "news.google.is",
-        "news.google.it",
-        "news.google.it.ao",
-        "news.google.je",
-        "news.google.jo",
-        "news.google.kg",
-        "news.google.ki",
-        "news.google.kz",
-        "news.google.la",
-        "news.google.li",
-        "news.google.lk",
-        "news.google.lt",
-        "news.google.lu",
-        "news.google.lv",
-        "news.google.md",
-        "news.google.me",
-        "news.google.mg",
-        "news.google.mk",
-        "news.google.ml",
-        "news.google.mn",
-        "news.google.ms",
-        "news.google.mu",
-        "news.google.mv",
-        "news.google.mw",
-        "news.google.ne",
-        "news.google.nl",
-        "news.google.no",
-        "news.google.nr",
-        "news.google.nu",
-        "news.google.pl",
-        "news.google.pn",
-        "news.google.ps",
-        "news.google.pt",
-        "news.google.ro",
-        "news.google.rs",
-        "news.google.ru",
-        "news.google.rw",
-        "news.google.sc",
-        "news.google.se",
-        "news.google.sh",
-        "news.google.si",
-        "news.google.sk",
-        "news.google.sm",
-        "news.google.sn",
-        "news.google.so",
-        "news.google.st",
-        "news.google.td",
-        "news.google.tg",
-        "news.google.tk",
-        "news.google.tl",
-        "news.google.tm",
-        "news.google.to",
-        "news.google.tt",
-        "news.google.us",
-        "news.google.vg",
-        "news.google.vu",
-        "news.google.ws"
-      ],
-      "parameters": ["q"]
-    },
-    "Zoohoo": {
-      "domains": ["zoohoo.cz"],
-      "parameters": ["q"]
-    },
-    "Seznam": {
-      "domains": ["search.seznam.cz"],
-      "parameters": ["q"]
-    },
-    "Online.no": {
-      "domains": ["online.no"],
-      "parameters": ["q"]
-    },
-    "Eurip": {
-      "domains": ["www.eurip.com"],
-      "parameters": ["q"]
-    },
-    "all.by": {
-      "domains": ["all.by"],
-      "parameters": ["query"]
-    },
-    "Road Runner Search": {
-      "domains": ["search.rr.com"],
-      "parameters": ["q"]
-    },
-    "Opplysningen 1881": {
-      "domains": ["www.1881.no"],
-      "parameters": ["Query"]
-    },
-    "YouGoo": {
-      "domains": ["www.yougoo.fr"],
-      "parameters": ["q"]
-    },
-    "Bing Images": {
-      "domains": ["bing.com/images/search", "www.bing.com/images/search"],
-      "parameters": ["q", "Q"]
-    },
-    "Geona": {
-      "domains": ["geona.net"],
-      "parameters": ["q"]
-    },
-    "Nate": {
-      "domains": ["search.nate.com"],
-      "parameters": ["q"]
-    },
-    "Search This": {
-      "domains": ["www.searchthis.com"],
-      "parameters": ["q"]
-    },
-    "DuckDuckGo": {
-      "domains": ["duckduckgo.com"],
-      "parameters": ["q"]
-    },
-    "Monster": {
-      "domains": [
-        "www.monster.be",
-        "www.monster.cz",
-        "www.monster.de",
-        "www.monster.fi",
-        "www.monster.fr",
-        "www.monster.ie",
-        "www.monster.it",
-        "www.monster.lu",
-        "www.monster.ch",
-        "www.monster.co.uk"
-      ],
-      "parameters": ["q"]
-    },
-    "Hotbot": {
-      "domains": ["www.hotbot.com"],
-      "parameters": ["query"]
-    },
-    "Kvasir": {
-      "domains": ["www.kvasir.no"],
-      "parameters": ["q"]
-    },
-    "Austronaut": {
-      "domains": ["www2.austronaut.at", "www1.astronaut.at"],
-      "parameters": ["q"]
-    },
-    "SoSoDesk": {
-      "domains": ["sosodesktop.com", "search.sosodesktop.com"],
-      "parameters": ["q"]
-    },
-    "Excite": {
-      "domains": [
-        "search.excite.it",
-        "search.excite.fr",
-        "search.excite.de",
-        "search.excite.co.uk",
-        "serach.excite.es",
-        "search.excite.nl",
-        "msxml.excite.com",
-        "www.excite.co.jp"
-      ],
-      "parameters": ["q", "search"]
-    },
-    "1&1": {
-      "domains": ["search.1and1.com"],
-      "parameters": ["q"]
-    },
-    "qip": {
-      "domains": ["search.qip.ru"],
-      "parameters": ["query"]
-    },
-    "Certified-Toolbar": {
-      "domains": ["search.certified-toolbar.com"],
-      "parameters": ["q"]
-    },
-    "Yahoo!": {
-      "domains": [
-        "search.yahoo.com",
-        "yahoo.com",
-        "ar.search.yahoo.com",
-        "ar.yahoo.com",
-        "au.search.yahoo.com",
-        "au.yahoo.com",
-        "br.search.yahoo.com",
-        "br.yahoo.com",
-        "ca.search.yahoo.com",
-        "ca.yahoo.com",
-        "cade.searchde.yahoo.com",
-        "cade.yahoo.com",
-        "chinese.searchinese.yahoo.com",
-        "chinese.yahoo.com",
-        "cn.search.yahoo.com",
-        "cn.yahoo.com",
-        "de.search.yahoo.com",
-        "de.yahoo.com",
-        "dk.search.yahoo.com",
-        "dk.yahoo.com",
-        "es.search.yahoo.com",
-        "es.yahoo.com",
-        "espanol.searchpanol.yahoo.com",
-        "espanol.yahoo.com",
-        "fr.search.yahoo.com",
-        "fr.yahoo.com",
-        "hk.search.yahoo.com",
-        "hk.yahoo.com",
-        "ie.search.yahoo.com",
-        "ie.yahoo.com",
-        "in.search.yahoo.com",
-        "in.yahoo.com",
-        "it.search.yahoo.com",
-        "it.yahoo.com",
-        "kr.search.yahoo.com",
-        "kr.yahoo.com",
-        "mx.search.yahoo.com",
-        "mx.yahoo.com",
-        "no.search.yahoo.com",
-        "no.yahoo.com",
-        "nz.search.yahoo.com",
-        "nz.yahoo.com",
-        "one.cn.yahoo.com",
-        "one.searchn.yahoo.com",
-        "qc.search.yahoo.com",
-        "qc.yahoo.com",
-        "ru.search.yahoo.com",
-        "ru.yahoo.com",
-        "se.search.yahoo.com",
-        "se.yahoo.com",
-        "search.searcharch.yahoo.com",
-        "tw.search.yahoo.com",
-        "tw.yahoo.com",
-        "uk.search.yahoo.com",
-        "uk.yahoo.com",
-        "us.search.yahoo.com",
-        "us.yahoo.com",
-        "www.yahoo.co.jp",
-        "search.yahoo.co.jp",
-        "www.cercato.it",
-        "search.offerbox.com",
-        "ys.mirostart.com"
-      ],
-      "parameters": ["p", "q"]
-    },
-    "URL.ORGanizier": {
-      "domains": ["www.url.org"],
-      "parameters": ["q"]
-    },
-    "Witch": {
-      "domains": ["www.witch.de"],
-      "parameters": ["search"]
-    },
-    "Mister Wong": {
-      "domains": ["www.mister-wong.com", "www.mister-wong.de"],
-      "parameters": ["Keywords"]
+      "parameters": ["query"],
+      "domains": ["apollo7.de"]
+    },
+    "Apontador": {
+      "parameters": ["q"],
+      "domains": ["apontador.com.br", "www.apontador.com.br"]
     },
     "Aport": {
-      "domains": ["sm.aport.ru"],
-      "parameters": ["r"]
+      "parameters": ["r"],
+      "domains": ["sm.aport.ru"]
     },
-    "Web.de": {
-      "domains": ["suche.web.de"],
-      "parameters": ["su"]
+    "arama": {
+      "parameters": ["q"],
+      "domains": ["arama.com"]
+    },
+    "Arcor": {
+      "parameters": ["Keywords"],
+      "domains": ["www.arcor.de"]
+    },
+    "Arianna": {
+      "parameters": ["query"],
+      "domains": ["arianna.libero.it", "www.arianna.com"]
     },
     "Ask": {
+      "parameters": ["q"],
       "domains": [
         "ask.com",
         "www.ask.com",
@@ -2284,14 +735,42 @@
         "uk.search-results.com",
         "www.search-results.com",
         "int.search-results.com"
-      ],
-      "parameters": ["q"]
+      ]
     },
-    "Centrum": {
-      "domains": ["serach.centrum.cz", "morfeo.centrum.cz"],
-      "parameters": ["q"]
+    "Ask Toolbar": {
+      "parameters": ["searchfor"],
+      "domains": ["search.tb.ask.com"]
+    },
+    "Atlas": {
+      "parameters": ["q"],
+      "domains": ["searchatlas.centrum.cz"]
+    },
+    "Austronaut": {
+      "parameters": ["q"],
+      "domains": ["www2.austronaut.at", "www1.astronaut.at"]
+    },
+    "Babylon": {
+      "parameters": ["q"],
+      "domains": ["search.babylon.com", "searchassist.babylon.com"]
+    },
+    "Baidu": {
+      "parameters": ["wd", "word", "kw", "k"],
+      "domains": [
+        "www.baidu.com",
+        "www1.baidu.com",
+        "zhidao.baidu.com",
+        "tieba.baidu.com",
+        "news.baidu.com",
+        "web.gougou.com",
+        "m.baidu.com"
+      ]
+    },
+    "Biglobe": {
+      "parameters": ["q"],
+      "domains": ["cgi.search.biglobe.ne.jp"]
     },
     "Bing": {
+      "parameters": ["q", "Q"],
       "domains": [
         "bing.com",
         "www.bing.com",
@@ -2299,62 +778,267 @@
         "dizionario.it.msn.com",
         "cc.bingj.com",
         "m.bing.com"
-      ],
-      "parameters": ["q", "Q"]
+      ]
     },
-    "Google Video": {
-      "domains": ["video.google.com"],
-      "parameters": ["q"]
-    },
-    "Delfi": {
-      "domains": ["otsing.delfi.ee"],
-      "parameters": ["q"]
+    "Bing Images": {
+      "parameters": ["q", "Q"],
+      "domains": ["bing.com/images/search", "www.bing.com/images/search"]
     },
     "blekko": {
-      "domains": ["blekko.com"],
-      "parameters": ["q"]
+      "parameters": ["q"],
+      "domains": ["blekko.com"]
     },
-    "Jyxo": {
-      "domains": ["jyxo.1188.cz"],
-      "parameters": ["q"]
+    "Blogdigger": {
+      "parameters": ["q"],
+      "domains": ["www.blogdigger.com"]
     },
-    "Kataweb": {
-      "domains": ["www.kataweb.it"],
-      "parameters": ["q"]
+    "Blogpulse": {
+      "parameters": ["query"],
+      "domains": ["www.blogpulse.com"]
     },
-    "uol.com.br": {
-      "domains": ["busca.uol.com.br"],
-      "parameters": ["q"]
+    "Bluewin": {
+      "parameters": ["searchTerm"],
+      "domains": ["search.bluewin.ch"]
     },
-    "Arianna": {
-      "domains": ["arianna.libero.it", "www.arianna.com"],
-      "parameters": ["query"]
+    "Brave": {
+      "parameters": ["q"],
+      "domains": ["search.brave.com"]
     },
-    "Mamma": {
-      "domains": ["www.mamma.com", "mamma75.mamma.com"],
-      "parameters": ["query"]
+    "British Telecommunications": {
+      "parameters": ["p"],
+      "domains": ["search.bt.com"]
     },
-    "Yatedo": {
-      "domains": ["www.yatedo.com", "www.yatedo.fr"],
-      "parameters": ["q"]
+    "canoe.ca": {
+      "parameters": ["q"],
+      "domains": ["web.canoe.ca"]
     },
-    "Twingly": {
-      "domains": ["www.twingly.com"],
-      "parameters": ["q"]
+    "Centrum": {
+      "parameters": ["q"],
+      "domains": ["serach.centrum.cz", "morfeo.centrum.cz"]
+    },
+    "Certified-Toolbar": {
+      "parameters": ["q"],
+      "domains": ["search.certified-toolbar.com"]
+    },
+    "Charter": {
+      "parameters": ["q"],
+      "domains": ["www.charter.net"]
+    },
+    "Clix": {
+      "parameters": ["question"],
+      "domains": ["pesquisa.clix.pt"]
+    },
+    "Coccoc": {
+      "parameters": ["q"],
+      "domains": ["coccoc.com"]
+    },
+    "Conduit": {
+      "parameters": ["q"],
+      "domains": ["search.conduit.com"]
+    },
+    "Comcast": {
+      "parameters": ["q"],
+      "domains": ["serach.comcast.net"]
+    },
+    "Crawler": {
+      "parameters": ["q"],
+      "domains": ["www.crawler.com"]
+    },
+    "Compuserve": {
+      "parameters": ["query"],
+      "domains": ["websearch.cs.com"]
+    },
+    "Cuil": {
+      "parameters": ["q"],
+      "domains": ["www.cuil.com"]
+    },
+    "Daemon search": {
+      "parameters": ["q"],
+      "domains": ["daemon-search.com", "my.daemon-search.com"]
+    },
+    "Dalesearch": {
+      "parameters": ["q"],
+      "domains": ["www.dalesearch.com"]
+    },
+    "DasOertliche": {
+      "parameters": ["kw"],
+      "domains": ["www.dasoertliche.de"]
+    },
+    "DasTelefonbuch": {
+      "parameters": ["kw"],
+      "domains": ["www1.dastelefonbuch.de"]
+    },
+    "Daum": {
+      "parameters": ["q"],
+      "domains": ["search.daum.net"]
     },
     "Delfi latvia": {
-      "domains": ["smart.delfi.lv"],
-      "parameters": ["q"]
+      "parameters": ["q"],
+      "domains": ["smart.delfi.lv"]
     },
-    "PriceRunner": {
-      "domains": ["www.pricerunner.co.uk"],
-      "parameters": ["q"]
+    "Delfi": {
+      "parameters": ["q"],
+      "domains": ["otsing.delfi.ee"]
     },
-    "Rakuten": {
-      "domains": ["websearch.rakuten.co.jp"],
-      "parameters": ["qt"]
+    "Digg": {
+      "parameters": ["s"],
+      "domains": ["digg.com"]
+    },
+    "dmoz": {
+      "parameters": ["q"],
+      "domains": ["dmoz.org", "editors.dmoz.org"]
+    },
+    "Dodo": {
+      "parameters": ["q"],
+      "domains": ["google.dodo.com.au"]
+    },
+    "DuckDuckGo": {
+      "parameters": ["q"],
+      "domains": ["duckduckgo.com"]
+    },
+    "earthlink": {
+      "parameters": ["q"],
+      "domains": ["search.earthlink.net"]
+    },
+    "Ecosia": {
+      "parameters": ["q"],
+      "domains": ["ecosia.org"]
+    },
+    "Eniro": {
+      "parameters": ["q", "search_word"],
+      "domains": ["www.eniro.se"]
+    },
+    "Eurip": {
+      "parameters": ["q"],
+      "domains": ["www.eurip.com"]
+    },
+    "Euroseek": {
+      "parameters": ["string"],
+      "domains": ["www.euroseek.com"]
+    },
+    "Everyclick": {
+      "parameters": ["keyword"],
+      "domains": ["www.everyclick.com"]
+    },
+    "Excite": {
+      "parameters": ["q", "search"],
+      "domains": [
+        "search.excite.it",
+        "search.excite.fr",
+        "search.excite.de",
+        "search.excite.co.uk",
+        "serach.excite.es",
+        "search.excite.nl",
+        "msxml.excite.com",
+        "www.excite.co.jp"
+      ]
+    },
+    "Exalead": {
+      "parameters": ["q"],
+      "domains": ["www.exalead.fr", "www.exalead.com"]
+    },
+    "eo": {
+      "parameters": ["x_query"],
+      "domains": ["eo.st"]
+    },
+    "Fast Browser Search": {
+      "parameters": ["q"],
+      "domains": ["www.fastbrowsersearch.com"]
+    },
+    "Francite": {
+      "parameters": ["name"],
+      "domains": ["recherche.francite.com"]
+    },
+    "Finderoo": {
+      "parameters": ["q"],
+      "domains": ["www.finderoo.com"]
+    },
+    "Findwide": {
+      "parameters": ["k"],
+      "domains": ["search.findwide.com"]
+    },
+    "Fireball": {
+      "parameters": ["q"],
+      "domains": ["www.fireball.de"]
+    },
+    "Firstfind": {
+      "parameters": ["qry"],
+      "domains": ["www.firstsfind.com"]
+    },
+    "Fixsuche": {
+      "parameters": ["q"],
+      "domains": ["www.fixsuche.de"]
+    },
+    "Flix": {
+      "parameters": ["keyword"],
+      "domains": ["www.flix.de"]
+    },
+    "Forestle": {
+      "parameters": ["q"],
+      "domains": ["forestle.org", "www.forestle.org", "forestle.mobi"]
+    },
+    "Free": {
+      "parameters": ["q"],
+      "domains": ["search.free.fr", "search1-2.free.fr", "search1-1.free.fr"]
+    },
+    "Freecause": {
+      "parameters": ["p"],
+      "domains": ["search.freecause.com"]
+    },
+    "Freenet": {
+      "parameters": ["query", "Keywords"],
+      "domains": ["suche.freenet.de"]
+    },
+    "Freshweather": {
+      "parameters": ["q"],
+      "domains": ["www.fresh-weather.com"]
+    },
+    "FriendFeed": {
+      "parameters": ["q"],
+      "domains": ["friendfeed.com"]
+    },
+    "GAIS": {
+      "parameters": ["q"],
+      "domains": ["gais.cs.ccu.edu.tw"]
+    },
+    "Geona": {
+      "parameters": ["q"],
+      "domains": ["geona.net"]
+    },
+    "Genieo": {
+      "parameters": ["q"],
+      "domains": ["search.genieo.com"]
+    },
+    "Gigablast": {
+      "parameters": ["q"],
+      "domains": ["www.gigablast.com", "dir.gigablast.com"]
+    },
+    "Globososo": {
+      "parameters": ["q"],
+      "domains": ["searches.globososo.com", "search.globososo.com"]
+    },
+    "GMX": {
+      "parameters": ["su"],
+      "domains": ["suche.gmx.net"]
+    },
+    "Gnadenmeer": {
+      "parameters": ["keyword"],
+      "domains": ["www.gnadenmeer.de"]
+    },
+    "Gomeo": {
+      "parameters": ["Keywords"],
+      "domains": ["www.gomeo.com"]
+    },
+    "goo": {
+      "parameters": ["MT"],
+      "domains": ["search.goo.ne.jp", "ocnsearch.goo.ne.jp"]
     },
     "Google": {
+      "parameters": [
+        "q",
+        "query # For www.cnn.com (powered by Google)",
+        "Keywords # For gooofullsearch.com (powered by Google)"
+      ],
       "domains": [
         "www.google.com",
         "www.google.ac",
@@ -2775,227 +1459,1961 @@
         "www.googleearth.fr",
         "webcache.googleusercontent.com",
         "encrypted.google.com",
-        "googlesyndicatedsearch.com",
-        "com.google.android.googlequicksearchbox"
-      ],
-      "parameters": ["q", "query", "Keywords"]
+        "googlesyndicatedsearch.com"
+      ]
     },
-    "Blogpulse": {
-      "domains": ["www.blogpulse.com"],
-      "parameters": ["query"]
+    "Google Blogsearch": {
+      "parameters": ["q"],
+      "domains": [
+        "blogsearch.google.ac",
+        "blogsearch.google.ad",
+        "blogsearch.google.ae",
+        "blogsearch.google.am",
+        "blogsearch.google.as",
+        "blogsearch.google.at",
+        "blogsearch.google.az",
+        "blogsearch.google.ba",
+        "blogsearch.google.be",
+        "blogsearch.google.bf",
+        "blogsearch.google.bg",
+        "blogsearch.google.bi",
+        "blogsearch.google.bj",
+        "blogsearch.google.bs",
+        "blogsearch.google.by",
+        "blogsearch.google.ca",
+        "blogsearch.google.cat",
+        "blogsearch.google.cc",
+        "blogsearch.google.cd",
+        "blogsearch.google.cf",
+        "blogsearch.google.cg",
+        "blogsearch.google.ch",
+        "blogsearch.google.ci",
+        "blogsearch.google.cl",
+        "blogsearch.google.cm",
+        "blogsearch.google.cn",
+        "blogsearch.google.co.bw",
+        "blogsearch.google.co.ck",
+        "blogsearch.google.co.cr",
+        "blogsearch.google.co.id",
+        "blogsearch.google.co.il",
+        "blogsearch.google.co.in",
+        "blogsearch.google.co.jp",
+        "blogsearch.google.co.ke",
+        "blogsearch.google.co.kr",
+        "blogsearch.google.co.ls",
+        "blogsearch.google.co.ma",
+        "blogsearch.google.co.mz",
+        "blogsearch.google.co.nz",
+        "blogsearch.google.co.th",
+        "blogsearch.google.co.tz",
+        "blogsearch.google.co.ug",
+        "blogsearch.google.co.uk",
+        "blogsearch.google.co.uz",
+        "blogsearch.google.co.ve",
+        "blogsearch.google.co.vi",
+        "blogsearch.google.co.za",
+        "blogsearch.google.co.zm",
+        "blogsearch.google.co.zw",
+        "blogsearch.google.com",
+        "blogsearch.google.com.af",
+        "blogsearch.google.com.ag",
+        "blogsearch.google.com.ai",
+        "blogsearch.google.com.ar",
+        "blogsearch.google.com.au",
+        "blogsearch.google.com.bd",
+        "blogsearch.google.com.bh",
+        "blogsearch.google.com.bn",
+        "blogsearch.google.com.bo",
+        "blogsearch.google.com.br",
+        "blogsearch.google.com.by",
+        "blogsearch.google.com.bz",
+        "blogsearch.google.com.co",
+        "blogsearch.google.com.cu",
+        "blogsearch.google.com.cy",
+        "blogsearch.google.com.do",
+        "blogsearch.google.com.ec",
+        "blogsearch.google.com.eg",
+        "blogsearch.google.com.et",
+        "blogsearch.google.com.fj",
+        "blogsearch.google.com.gh",
+        "blogsearch.google.com.gi",
+        "blogsearch.google.com.gt",
+        "blogsearch.google.com.hk",
+        "blogsearch.google.com.jm",
+        "blogsearch.google.com.kh",
+        "blogsearch.google.com.kw",
+        "blogsearch.google.com.lb",
+        "blogsearch.google.com.lc",
+        "blogsearch.google.com.ly",
+        "blogsearch.google.com.mt",
+        "blogsearch.google.com.mx",
+        "blogsearch.google.com.my",
+        "blogsearch.google.com.na",
+        "blogsearch.google.com.nf",
+        "blogsearch.google.com.ng",
+        "blogsearch.google.com.ni",
+        "blogsearch.google.com.np",
+        "blogsearch.google.com.om",
+        "blogsearch.google.com.pa",
+        "blogsearch.google.com.pe",
+        "blogsearch.google.com.ph",
+        "blogsearch.google.com.pk",
+        "blogsearch.google.com.pr",
+        "blogsearch.google.com.py",
+        "blogsearch.google.com.qa",
+        "blogsearch.google.com.sa",
+        "blogsearch.google.com.sb",
+        "blogsearch.google.com.sg",
+        "blogsearch.google.com.sl",
+        "blogsearch.google.com.sv",
+        "blogsearch.google.com.tj",
+        "blogsearch.google.com.tn",
+        "blogsearch.google.com.tr",
+        "blogsearch.google.com.tw",
+        "blogsearch.google.com.ua",
+        "blogsearch.google.com.uy",
+        "blogsearch.google.com.vc",
+        "blogsearch.google.com.vn",
+        "blogsearch.google.cv",
+        "blogsearch.google.cz",
+        "blogsearch.google.de",
+        "blogsearch.google.dj",
+        "blogsearch.google.dk",
+        "blogsearch.google.dm",
+        "blogsearch.google.dz",
+        "blogsearch.google.ee",
+        "blogsearch.google.es",
+        "blogsearch.google.fi",
+        "blogsearch.google.fm",
+        "blogsearch.google.fr",
+        "blogsearch.google.ga",
+        "blogsearch.google.gd",
+        "blogsearch.google.ge",
+        "blogsearch.google.gf",
+        "blogsearch.google.gg",
+        "blogsearch.google.gl",
+        "blogsearch.google.gm",
+        "blogsearch.google.gp",
+        "blogsearch.google.gr",
+        "blogsearch.google.gy",
+        "blogsearch.google.hn",
+        "blogsearch.google.hr",
+        "blogsearch.google.ht",
+        "blogsearch.google.hu",
+        "blogsearch.google.ie",
+        "blogsearch.google.im",
+        "blogsearch.google.io",
+        "blogsearch.google.iq",
+        "blogsearch.google.is",
+        "blogsearch.google.it",
+        "blogsearch.google.it.ao",
+        "blogsearch.google.je",
+        "blogsearch.google.jo",
+        "blogsearch.google.kg",
+        "blogsearch.google.ki",
+        "blogsearch.google.kz",
+        "blogsearch.google.la",
+        "blogsearch.google.li",
+        "blogsearch.google.lk",
+        "blogsearch.google.lt",
+        "blogsearch.google.lu",
+        "blogsearch.google.lv",
+        "blogsearch.google.md",
+        "blogsearch.google.me",
+        "blogsearch.google.mg",
+        "blogsearch.google.mk",
+        "blogsearch.google.ml",
+        "blogsearch.google.mn",
+        "blogsearch.google.ms",
+        "blogsearch.google.mu",
+        "blogsearch.google.mv",
+        "blogsearch.google.mw",
+        "blogsearch.google.ne",
+        "blogsearch.google.nl",
+        "blogsearch.google.no",
+        "blogsearch.google.nr",
+        "blogsearch.google.nu",
+        "blogsearch.google.pl",
+        "blogsearch.google.pn",
+        "blogsearch.google.ps",
+        "blogsearch.google.pt",
+        "blogsearch.google.ro",
+        "blogsearch.google.rs",
+        "blogsearch.google.ru",
+        "blogsearch.google.rw",
+        "blogsearch.google.sc",
+        "blogsearch.google.se",
+        "blogsearch.google.sh",
+        "blogsearch.google.si",
+        "blogsearch.google.sk",
+        "blogsearch.google.sm",
+        "blogsearch.google.sn",
+        "blogsearch.google.so",
+        "blogsearch.google.st",
+        "blogsearch.google.td",
+        "blogsearch.google.tg",
+        "blogsearch.google.tk",
+        "blogsearch.google.tl",
+        "blogsearch.google.tm",
+        "blogsearch.google.to",
+        "blogsearch.google.tt",
+        "blogsearch.google.us",
+        "blogsearch.google.vg",
+        "blogsearch.google.vu",
+        "blogsearch.google.ws"
+      ]
     },
-    "Hooseek.com": {
-      "domains": ["www.hooseek.com"],
-      "parameters": ["recherche"]
+    "Google Images": {
+      "parameters": ["q"],
+      "domains": [
+        "google.ac/imgres",
+        "google.ad/imgres",
+        "google.ae/imgres",
+        "google.am/imgres",
+        "google.as/imgres",
+        "google.at/imgres",
+        "google.az/imgres",
+        "google.ba/imgres",
+        "google.be/imgres",
+        "google.bf/imgres",
+        "google.bg/imgres",
+        "google.bi/imgres",
+        "google.bj/imgres",
+        "google.bs/imgres",
+        "google.by/imgres",
+        "google.ca/imgres",
+        "google.cat/imgres",
+        "google.cc/imgres",
+        "google.cd/imgres",
+        "google.cf/imgres",
+        "google.cg/imgres",
+        "google.ch/imgres",
+        "google.ci/imgres",
+        "google.cl/imgres",
+        "google.cm/imgres",
+        "google.cn/imgres",
+        "google.co.bw/imgres",
+        "google.co.ck/imgres",
+        "google.co.cr/imgres",
+        "google.co.id/imgres",
+        "google.co.il/imgres",
+        "google.co.in/imgres",
+        "google.co.jp/imgres",
+        "google.co.ke/imgres",
+        "google.co.kr/imgres",
+        "google.co.ls/imgres",
+        "google.co.ma/imgres",
+        "google.co.mz/imgres",
+        "google.co.nz/imgres",
+        "google.co.th/imgres",
+        "google.co.tz/imgres",
+        "google.co.ug/imgres",
+        "google.co.uk/imgres",
+        "google.co.uz/imgres",
+        "google.co.ve/imgres",
+        "google.co.vi/imgres",
+        "google.co.za/imgres",
+        "google.co.zm/imgres",
+        "google.co.zw/imgres",
+        "google.com/imgres",
+        "google.com.af/imgres",
+        "google.com.ag/imgres",
+        "google.com.ai/imgres",
+        "google.com.ar/imgres",
+        "google.com.au/imgres",
+        "google.com.bd/imgres",
+        "google.com.bh/imgres",
+        "google.com.bn/imgres",
+        "google.com.bo/imgres",
+        "google.com.br/imgres",
+        "google.com.by/imgres",
+        "google.com.bz/imgres",
+        "google.com.co/imgres",
+        "google.com.cu/imgres",
+        "google.com.cy/imgres",
+        "google.com.do/imgres",
+        "google.com.ec/imgres",
+        "google.com.eg/imgres",
+        "google.com.et/imgres",
+        "google.com.fj/imgres",
+        "google.com.gh/imgres",
+        "google.com.gi/imgres",
+        "google.com.gt/imgres",
+        "google.com.hk/imgres",
+        "google.com.jm/imgres",
+        "google.com.kh/imgres",
+        "google.com.kw/imgres",
+        "google.com.lb/imgres",
+        "google.com.lc/imgres",
+        "google.com.ly/imgres",
+        "google.com.mt/imgres",
+        "google.com.mx/imgres",
+        "google.com.my/imgres",
+        "google.com.na/imgres",
+        "google.com.nf/imgres",
+        "google.com.ng/imgres",
+        "google.com.ni/imgres",
+        "google.com.np/imgres",
+        "google.com.om/imgres",
+        "google.com.pa/imgres",
+        "google.com.pe/imgres",
+        "google.com.ph/imgres",
+        "google.com.pk/imgres",
+        "google.com.pr/imgres",
+        "google.com.py/imgres",
+        "google.com.qa/imgres",
+        "google.com.sa/imgres",
+        "google.com.sb/imgres",
+        "google.com.sg/imgres",
+        "google.com.sl/imgres",
+        "google.com.sv/imgres",
+        "google.com.tj/imgres",
+        "google.com.tn/imgres",
+        "google.com.tr/imgres",
+        "google.com.tw/imgres",
+        "google.com.ua/imgres",
+        "google.com.uy/imgres",
+        "google.com.vc/imgres",
+        "google.com.vn/imgres",
+        "google.cv/imgres",
+        "google.cz/imgres",
+        "google.de/imgres",
+        "google.dj/imgres",
+        "google.dk/imgres",
+        "google.dm/imgres",
+        "google.dz/imgres",
+        "google.ee/imgres",
+        "google.es/imgres",
+        "google.fi/imgres",
+        "google.fm/imgres",
+        "google.fr/imgres",
+        "google.ga/imgres",
+        "google.gd/imgres",
+        "google.ge/imgres",
+        "google.gf/imgres",
+        "google.gg/imgres",
+        "google.gl/imgres",
+        "google.gm/imgres",
+        "google.gp/imgres",
+        "google.gr/imgres",
+        "google.gy/imgres",
+        "google.hn/imgres",
+        "google.hr/imgres",
+        "google.ht/imgres",
+        "google.hu/imgres",
+        "google.ie/imgres",
+        "google.im/imgres",
+        "google.io/imgres",
+        "google.iq/imgres",
+        "google.is/imgres",
+        "google.it/imgres",
+        "google.it.ao/imgres",
+        "google.je/imgres",
+        "google.jo/imgres",
+        "google.kg/imgres",
+        "google.ki/imgres",
+        "google.kz/imgres",
+        "google.la/imgres",
+        "google.li/imgres",
+        "google.lk/imgres",
+        "google.lt/imgres",
+        "google.lu/imgres",
+        "google.lv/imgres",
+        "google.md/imgres",
+        "google.me/imgres",
+        "google.mg/imgres",
+        "google.mk/imgres",
+        "google.ml/imgres",
+        "google.mn/imgres",
+        "google.ms/imgres",
+        "google.mu/imgres",
+        "google.mv/imgres",
+        "google.mw/imgres",
+        "google.ne/imgres",
+        "google.nl/imgres",
+        "google.no/imgres",
+        "google.nr/imgres",
+        "google.nu/imgres",
+        "google.pl/imgres",
+        "google.pn/imgres",
+        "google.ps/imgres",
+        "google.pt/imgres",
+        "google.ro/imgres",
+        "google.rs/imgres",
+        "google.ru/imgres",
+        "google.rw/imgres",
+        "google.sc/imgres",
+        "google.se/imgres",
+        "google.sh/imgres",
+        "google.si/imgres",
+        "google.sk/imgres",
+        "google.sm/imgres",
+        "google.sn/imgres",
+        "google.so/imgres",
+        "google.st/imgres",
+        "google.td/imgres",
+        "google.tg/imgres",
+        "google.tk/imgres",
+        "google.tl/imgres",
+        "google.tm/imgres",
+        "google.to/imgres",
+        "google.tt/imgres",
+        "google.us/imgres",
+        "google.vg/imgres",
+        "google.vu/imgres",
+        "images.google.ws",
+        "images.google.ac",
+        "images.google.ad",
+        "images.google.ae",
+        "images.google.am",
+        "images.google.as",
+        "images.google.at",
+        "images.google.az",
+        "images.google.ba",
+        "images.google.be",
+        "images.google.bf",
+        "images.google.bg",
+        "images.google.bi",
+        "images.google.bj",
+        "images.google.bs",
+        "images.google.by",
+        "images.google.ca",
+        "images.google.cat",
+        "images.google.cc",
+        "images.google.cd",
+        "images.google.cf",
+        "images.google.cg",
+        "images.google.ch",
+        "images.google.ci",
+        "images.google.cl",
+        "images.google.cm",
+        "images.google.cn",
+        "images.google.co.bw",
+        "images.google.co.ck",
+        "images.google.co.cr",
+        "images.google.co.id",
+        "images.google.co.il",
+        "images.google.co.in",
+        "images.google.co.jp",
+        "images.google.co.ke",
+        "images.google.co.kr",
+        "images.google.co.ls",
+        "images.google.co.ma",
+        "images.google.co.mz",
+        "images.google.co.nz",
+        "images.google.co.th",
+        "images.google.co.tz",
+        "images.google.co.ug",
+        "images.google.co.uk",
+        "images.google.co.uz",
+        "images.google.co.ve",
+        "images.google.co.vi",
+        "images.google.co.za",
+        "images.google.co.zm",
+        "images.google.co.zw",
+        "images.google.com",
+        "images.google.com.af",
+        "images.google.com.ag",
+        "images.google.com.ai",
+        "images.google.com.ar",
+        "images.google.com.au",
+        "images.google.com.bd",
+        "images.google.com.bh",
+        "images.google.com.bn",
+        "images.google.com.bo",
+        "images.google.com.br",
+        "images.google.com.by",
+        "images.google.com.bz",
+        "images.google.com.co",
+        "images.google.com.cu",
+        "images.google.com.cy",
+        "images.google.com.do",
+        "images.google.com.ec",
+        "images.google.com.eg",
+        "images.google.com.et",
+        "images.google.com.fj",
+        "images.google.com.gh",
+        "images.google.com.gi",
+        "images.google.com.gt",
+        "images.google.com.hk",
+        "images.google.com.jm",
+        "images.google.com.kh",
+        "images.google.com.kw",
+        "images.google.com.lb",
+        "images.google.com.lc",
+        "images.google.com.ly",
+        "images.google.com.mt",
+        "images.google.com.mx",
+        "images.google.com.my",
+        "images.google.com.na",
+        "images.google.com.nf",
+        "images.google.com.ng",
+        "images.google.com.ni",
+        "images.google.com.np",
+        "images.google.com.om",
+        "images.google.com.pa",
+        "images.google.com.pe",
+        "images.google.com.ph",
+        "images.google.com.pk",
+        "images.google.com.pr",
+        "images.google.com.py",
+        "images.google.com.qa",
+        "images.google.com.sa",
+        "images.google.com.sb",
+        "images.google.com.sg",
+        "images.google.com.sl",
+        "images.google.com.sv",
+        "images.google.com.tj",
+        "images.google.com.tn",
+        "images.google.com.tr",
+        "images.google.com.tw",
+        "images.google.com.ua",
+        "images.google.com.uy",
+        "images.google.com.vc",
+        "images.google.com.vn",
+        "images.google.cv",
+        "images.google.cz",
+        "images.google.de",
+        "images.google.dj",
+        "images.google.dk",
+        "images.google.dm",
+        "images.google.dz",
+        "images.google.ee",
+        "images.google.es",
+        "images.google.fi",
+        "images.google.fm",
+        "images.google.fr",
+        "images.google.ga",
+        "images.google.gd",
+        "images.google.ge",
+        "images.google.gf",
+        "images.google.gg",
+        "images.google.gl",
+        "images.google.gm",
+        "images.google.gp",
+        "images.google.gr",
+        "images.google.gy",
+        "images.google.hn",
+        "images.google.hr",
+        "images.google.ht",
+        "images.google.hu",
+        "images.google.ie",
+        "images.google.im",
+        "images.google.io",
+        "images.google.iq",
+        "images.google.is",
+        "images.google.it",
+        "images.google.it.ao",
+        "images.google.je",
+        "images.google.jo",
+        "images.google.kg",
+        "images.google.ki",
+        "images.google.kz",
+        "images.google.la",
+        "images.google.li",
+        "images.google.lk",
+        "images.google.lt",
+        "images.google.lu",
+        "images.google.lv",
+        "images.google.md",
+        "images.google.me",
+        "images.google.mg",
+        "images.google.mk",
+        "images.google.ml",
+        "images.google.mn",
+        "images.google.ms",
+        "images.google.mu",
+        "images.google.mv",
+        "images.google.mw",
+        "images.google.ne",
+        "images.google.nl",
+        "images.google.no",
+        "images.google.nr",
+        "images.google.nu",
+        "images.google.pl",
+        "images.google.pn",
+        "images.google.ps",
+        "images.google.pt",
+        "images.google.ro",
+        "images.google.rs",
+        "images.google.ru",
+        "images.google.rw",
+        "images.google.sc",
+        "images.google.se",
+        "images.google.sh",
+        "images.google.si",
+        "images.google.sk",
+        "images.google.sm",
+        "images.google.sn",
+        "images.google.so",
+        "images.google.st",
+        "images.google.td",
+        "images.google.tg",
+        "images.google.tk",
+        "images.google.tl",
+        "images.google.tm",
+        "images.google.to",
+        "images.google.tt",
+        "images.google.us",
+        "images.google.vg",
+        "images.google.vu"
+      ]
     },
-    "Dalesearch": {
-      "domains": ["www.dalesearch.com"],
-      "parameters": ["q"]
+    "Google News": {
+      "parameters": ["q"],
+      "domains": [
+        "news.google.ac",
+        "news.google.ad",
+        "news.google.ae",
+        "news.google.am",
+        "news.google.as",
+        "news.google.at",
+        "news.google.az",
+        "news.google.ba",
+        "news.google.be",
+        "news.google.bf",
+        "news.google.bg",
+        "news.google.bi",
+        "news.google.bj",
+        "news.google.bs",
+        "news.google.by",
+        "news.google.ca",
+        "news.google.cat",
+        "news.google.cc",
+        "news.google.cd",
+        "news.google.cf",
+        "news.google.cg",
+        "news.google.ch",
+        "news.google.ci",
+        "news.google.cl",
+        "news.google.cm",
+        "news.google.cn",
+        "news.google.co.bw",
+        "news.google.co.ck",
+        "news.google.co.cr",
+        "news.google.co.id",
+        "news.google.co.il",
+        "news.google.co.in",
+        "news.google.co.jp",
+        "news.google.co.ke",
+        "news.google.co.kr",
+        "news.google.co.ls",
+        "news.google.co.ma",
+        "news.google.co.mz",
+        "news.google.co.nz",
+        "news.google.co.th",
+        "news.google.co.tz",
+        "news.google.co.ug",
+        "news.google.co.uk",
+        "news.google.co.uz",
+        "news.google.co.ve",
+        "news.google.co.vi",
+        "news.google.co.za",
+        "news.google.co.zm",
+        "news.google.co.zw",
+        "news.google.com",
+        "news.google.com.af",
+        "news.google.com.ag",
+        "news.google.com.ai",
+        "news.google.com.ar",
+        "news.google.com.au",
+        "news.google.com.bd",
+        "news.google.com.bh",
+        "news.google.com.bn",
+        "news.google.com.bo",
+        "news.google.com.br",
+        "news.google.com.by",
+        "news.google.com.bz",
+        "news.google.com.co",
+        "news.google.com.cu",
+        "news.google.com.cy",
+        "news.google.com.do",
+        "news.google.com.ec",
+        "news.google.com.eg",
+        "news.google.com.et",
+        "news.google.com.fj",
+        "news.google.com.gh",
+        "news.google.com.gi",
+        "news.google.com.gt",
+        "news.google.com.hk",
+        "news.google.com.jm",
+        "news.google.com.kh",
+        "news.google.com.kw",
+        "news.google.com.lb",
+        "news.google.com.lc",
+        "news.google.com.ly",
+        "news.google.com.mt",
+        "news.google.com.mx",
+        "news.google.com.my",
+        "news.google.com.na",
+        "news.google.com.nf",
+        "news.google.com.ng",
+        "news.google.com.ni",
+        "news.google.com.np",
+        "news.google.com.om",
+        "news.google.com.pa",
+        "news.google.com.pe",
+        "news.google.com.ph",
+        "news.google.com.pk",
+        "news.google.com.pr",
+        "news.google.com.py",
+        "news.google.com.qa",
+        "news.google.com.sa",
+        "news.google.com.sb",
+        "news.google.com.sg",
+        "news.google.com.sl",
+        "news.google.com.sv",
+        "news.google.com.tj",
+        "news.google.com.tn",
+        "news.google.com.tr",
+        "news.google.com.tw",
+        "news.google.com.ua",
+        "news.google.com.uy",
+        "news.google.com.vc",
+        "news.google.com.vn",
+        "news.google.cv",
+        "news.google.cz",
+        "news.google.de",
+        "news.google.dj",
+        "news.google.dk",
+        "news.google.dm",
+        "news.google.dz",
+        "news.google.ee",
+        "news.google.es",
+        "news.google.fi",
+        "news.google.fm",
+        "news.google.fr",
+        "news.google.ga",
+        "news.google.gd",
+        "news.google.ge",
+        "news.google.gf",
+        "news.google.gg",
+        "news.google.gl",
+        "news.google.gm",
+        "news.google.gp",
+        "news.google.gr",
+        "news.google.gy",
+        "news.google.hn",
+        "news.google.hr",
+        "news.google.ht",
+        "news.google.hu",
+        "news.google.ie",
+        "news.google.im",
+        "news.google.io",
+        "news.google.iq",
+        "news.google.is",
+        "news.google.it",
+        "news.google.it.ao",
+        "news.google.je",
+        "news.google.jo",
+        "news.google.kg",
+        "news.google.ki",
+        "news.google.kz",
+        "news.google.la",
+        "news.google.li",
+        "news.google.lk",
+        "news.google.lt",
+        "news.google.lu",
+        "news.google.lv",
+        "news.google.md",
+        "news.google.me",
+        "news.google.mg",
+        "news.google.mk",
+        "news.google.ml",
+        "news.google.mn",
+        "news.google.ms",
+        "news.google.mu",
+        "news.google.mv",
+        "news.google.mw",
+        "news.google.ne",
+        "news.google.nl",
+        "news.google.no",
+        "news.google.nr",
+        "news.google.nu",
+        "news.google.pl",
+        "news.google.pn",
+        "news.google.ps",
+        "news.google.pt",
+        "news.google.ro",
+        "news.google.rs",
+        "news.google.ru",
+        "news.google.rw",
+        "news.google.sc",
+        "news.google.se",
+        "news.google.sh",
+        "news.google.si",
+        "news.google.sk",
+        "news.google.sm",
+        "news.google.sn",
+        "news.google.so",
+        "news.google.st",
+        "news.google.td",
+        "news.google.tg",
+        "news.google.tk",
+        "news.google.tl",
+        "news.google.tm",
+        "news.google.to",
+        "news.google.tt",
+        "news.google.us",
+        "news.google.vg",
+        "news.google.vu",
+        "news.google.ws"
+      ]
     },
-    "Alice Adsl": {
-      "domains": ["rechercher.aliceadsl.fr"],
-      "parameters": ["q"]
+    "Google Product Search": {
+      "parameters": ["q"],
+      "domains": [
+        "google.ac/products",
+        "google.ad/products",
+        "google.ae/products",
+        "google.am/products",
+        "google.as/products",
+        "google.at/products",
+        "google.az/products",
+        "google.ba/products",
+        "google.be/products",
+        "google.bf/products",
+        "google.bg/products",
+        "google.bi/products",
+        "google.bj/products",
+        "google.bs/products",
+        "google.by/products",
+        "google.ca/products",
+        "google.cat/products",
+        "google.cc/products",
+        "google.cd/products",
+        "google.cf/products",
+        "google.cg/products",
+        "google.ch/products",
+        "google.ci/products",
+        "google.cl/products",
+        "google.cm/products",
+        "google.cn/products",
+        "google.co.bw/products",
+        "google.co.ck/products",
+        "google.co.cr/products",
+        "google.co.id/products",
+        "google.co.il/products",
+        "google.co.in/products",
+        "google.co.jp/products",
+        "google.co.ke/products",
+        "google.co.kr/products",
+        "google.co.ls/products",
+        "google.co.ma/products",
+        "google.co.mz/products",
+        "google.co.nz/products",
+        "google.co.th/products",
+        "google.co.tz/products",
+        "google.co.ug/products",
+        "google.co.uk/products",
+        "google.co.uz/products",
+        "google.co.ve/products",
+        "google.co.vi/products",
+        "google.co.za/products",
+        "google.co.zm/products",
+        "google.co.zw/products",
+        "google.com/products",
+        "google.com.af/products",
+        "google.com.ag/products",
+        "google.com.ai/products",
+        "google.com.ar/products",
+        "google.com.au/products",
+        "google.com.bd/products",
+        "google.com.bh/products",
+        "google.com.bn/products",
+        "google.com.bo/products",
+        "google.com.br/products",
+        "google.com.by/products",
+        "google.com.bz/products",
+        "google.com.co/products",
+        "google.com.cu/products",
+        "google.com.cy/products",
+        "google.com.do/products",
+        "google.com.ec/products",
+        "google.com.eg/products",
+        "google.com.et/products",
+        "google.com.fj/products",
+        "google.com.gh/products",
+        "google.com.gi/products",
+        "google.com.gt/products",
+        "google.com.hk/products",
+        "google.com.jm/products",
+        "google.com.kh/products",
+        "google.com.kw/products",
+        "google.com.lb/products",
+        "google.com.lc/products",
+        "google.com.ly/products",
+        "google.com.mt/products",
+        "google.com.mx/products",
+        "google.com.my/products",
+        "google.com.na/products",
+        "google.com.nf/products",
+        "google.com.ng/products",
+        "google.com.ni/products",
+        "google.com.np/products",
+        "google.com.om/products",
+        "google.com.pa/products",
+        "google.com.pe/products",
+        "google.com.ph/products",
+        "google.com.pk/products",
+        "google.com.pr/products",
+        "google.com.py/products",
+        "google.com.qa/products",
+        "google.com.sa/products",
+        "google.com.sb/products",
+        "google.com.sg/products",
+        "google.com.sl/products",
+        "google.com.sv/products",
+        "google.com.tj/products",
+        "google.com.tn/products",
+        "google.com.tr/products",
+        "google.com.tw/products",
+        "google.com.ua/products",
+        "google.com.uy/products",
+        "google.com.vc/products",
+        "google.com.vn/products",
+        "google.cv/products",
+        "google.cz/products",
+        "google.de/products",
+        "google.dj/products",
+        "google.dk/products",
+        "google.dm/products",
+        "google.dz/products",
+        "google.ee/products",
+        "google.es/products",
+        "google.fi/products",
+        "google.fm/products",
+        "google.fr/products",
+        "google.ga/products",
+        "google.gd/products",
+        "google.ge/products",
+        "google.gf/products",
+        "google.gg/products",
+        "google.gl/products",
+        "google.gm/products",
+        "google.gp/products",
+        "google.gr/products",
+        "google.gy/products",
+        "google.hn/products",
+        "google.hr/products",
+        "google.ht/products",
+        "google.hu/products",
+        "google.ie/products",
+        "google.im/products",
+        "google.io/products",
+        "google.iq/products",
+        "google.is/products",
+        "google.it/products",
+        "google.it.ao/products",
+        "google.je/products",
+        "google.jo/products",
+        "google.kg/products",
+        "google.ki/products",
+        "google.kz/products",
+        "google.la/products",
+        "google.li/products",
+        "google.lk/products",
+        "google.lt/products",
+        "google.lu/products",
+        "google.lv/products",
+        "google.md/products",
+        "google.me/products",
+        "google.mg/products",
+        "google.mk/products",
+        "google.ml/products",
+        "google.mn/products",
+        "google.ms/products",
+        "google.mu/products",
+        "google.mv/products",
+        "google.mw/products",
+        "google.ne/products",
+        "google.nl/products",
+        "google.no/products",
+        "google.nr/products",
+        "google.nu/products",
+        "google.pl/products",
+        "google.pn/products",
+        "google.ps/products",
+        "google.pt/products",
+        "google.ro/products",
+        "google.rs/products",
+        "google.ru/products",
+        "google.rw/products",
+        "google.sc/products",
+        "google.se/products",
+        "google.sh/products",
+        "google.si/products",
+        "google.sk/products",
+        "google.sm/products",
+        "google.sn/products",
+        "google.so/products",
+        "google.st/products",
+        "google.td/products",
+        "google.tg/products",
+        "google.tk/products",
+        "google.tl/products",
+        "google.tm/products",
+        "google.to/products",
+        "google.tt/products",
+        "google.us/products",
+        "google.vg/products",
+        "google.vu/products",
+        "google.ws/products",
+        "www.google.ac/products",
+        "www.google.ad/products",
+        "www.google.ae/products",
+        "www.google.am/products",
+        "www.google.as/products",
+        "www.google.at/products",
+        "www.google.az/products",
+        "www.google.ba/products",
+        "www.google.be/products",
+        "www.google.bf/products",
+        "www.google.bg/products",
+        "www.google.bi/products",
+        "www.google.bj/products",
+        "www.google.bs/products",
+        "www.google.by/products",
+        "www.google.ca/products",
+        "www.google.cat/products",
+        "www.google.cc/products",
+        "www.google.cd/products",
+        "www.google.cf/products",
+        "www.google.cg/products",
+        "www.google.ch/products",
+        "www.google.ci/products",
+        "www.google.cl/products",
+        "www.google.cm/products",
+        "www.google.cn/products",
+        "www.google.co.bw/products",
+        "www.google.co.ck/products",
+        "www.google.co.cr/products",
+        "www.google.co.id/products",
+        "www.google.co.il/products",
+        "www.google.co.in/products",
+        "www.google.co.jp/products",
+        "www.google.co.ke/products",
+        "www.google.co.kr/products",
+        "www.google.co.ls/products",
+        "www.google.co.ma/products",
+        "www.google.co.mz/products",
+        "www.google.co.nz/products",
+        "www.google.co.th/products",
+        "www.google.co.tz/products",
+        "www.google.co.ug/products",
+        "www.google.co.uk/products",
+        "www.google.co.uz/products",
+        "www.google.co.ve/products",
+        "www.google.co.vi/products",
+        "www.google.co.za/products",
+        "www.google.co.zm/products",
+        "www.google.co.zw/products",
+        "www.google.com/products",
+        "www.google.com.af/products",
+        "www.google.com.ag/products",
+        "www.google.com.ai/products",
+        "www.google.com.ar/products",
+        "www.google.com.au/products",
+        "www.google.com.bd/products",
+        "www.google.com.bh/products",
+        "www.google.com.bn/products",
+        "www.google.com.bo/products",
+        "www.google.com.br/products",
+        "www.google.com.by/products",
+        "www.google.com.bz/products",
+        "www.google.com.co/products",
+        "www.google.com.cu/products",
+        "www.google.com.cy/products",
+        "www.google.com.do/products",
+        "www.google.com.ec/products",
+        "www.google.com.eg/products",
+        "www.google.com.et/products",
+        "www.google.com.fj/products",
+        "www.google.com.gh/products",
+        "www.google.com.gi/products",
+        "www.google.com.gt/products",
+        "www.google.com.hk/products",
+        "www.google.com.jm/products",
+        "www.google.com.kh/products",
+        "www.google.com.kw/products",
+        "www.google.com.lb/products",
+        "www.google.com.lc/products",
+        "www.google.com.ly/products",
+        "www.google.com.mt/products",
+        "www.google.com.mx/products",
+        "www.google.com.my/products",
+        "www.google.com.na/products",
+        "www.google.com.nf/products",
+        "www.google.com.ng/products",
+        "www.google.com.ni/products",
+        "www.google.com.np/products",
+        "www.google.com.om/products",
+        "www.google.com.pa/products",
+        "www.google.com.pe/products",
+        "www.google.com.ph/products",
+        "www.google.com.pk/products",
+        "www.google.com.pr/products",
+        "www.google.com.py/products",
+        "www.google.com.qa/products",
+        "www.google.com.sa/products",
+        "www.google.com.sb/products",
+        "www.google.com.sg/products",
+        "www.google.com.sl/products",
+        "www.google.com.sv/products",
+        "www.google.com.tj/products",
+        "www.google.com.tn/products",
+        "www.google.com.tr/products",
+        "www.google.com.tw/products",
+        "www.google.com.ua/products",
+        "www.google.com.uy/products",
+        "www.google.com.vc/products",
+        "www.google.com.vn/products",
+        "www.google.cv/products",
+        "www.google.cz/products",
+        "www.google.de/products",
+        "www.google.dj/products",
+        "www.google.dk/products",
+        "www.google.dm/products",
+        "www.google.dz/products",
+        "www.google.ee/products",
+        "www.google.es/products",
+        "www.google.fi/products",
+        "www.google.fm/products",
+        "www.google.fr/products",
+        "www.google.ga/products",
+        "www.google.gd/products",
+        "www.google.ge/products",
+        "www.google.gf/products",
+        "www.google.gg/products",
+        "www.google.gl/products",
+        "www.google.gm/products",
+        "www.google.gp/products",
+        "www.google.gr/products",
+        "www.google.gy/products",
+        "www.google.hn/products",
+        "www.google.hr/products",
+        "www.google.ht/products",
+        "www.google.hu/products",
+        "www.google.ie/products",
+        "www.google.im/products",
+        "www.google.io/products",
+        "www.google.iq/products",
+        "www.google.is/products",
+        "www.google.it/products",
+        "www.google.it.ao/products",
+        "www.google.je/products",
+        "www.google.jo/products",
+        "www.google.kg/products",
+        "www.google.ki/products",
+        "www.google.kz/products",
+        "www.google.la/products",
+        "www.google.li/products",
+        "www.google.lk/products",
+        "www.google.lt/products",
+        "www.google.lu/products",
+        "www.google.lv/products",
+        "www.google.md/products",
+        "www.google.me/products",
+        "www.google.mg/products",
+        "www.google.mk/products",
+        "www.google.ml/products",
+        "www.google.mn/products",
+        "www.google.ms/products",
+        "www.google.mu/products",
+        "www.google.mv/products",
+        "www.google.mw/products",
+        "www.google.ne/products",
+        "www.google.nl/products",
+        "www.google.no/products",
+        "www.google.nr/products",
+        "www.google.nu/products",
+        "www.google.pl/products",
+        "www.google.pn/products",
+        "www.google.ps/products",
+        "www.google.pt/products",
+        "www.google.ro/products",
+        "www.google.rs/products",
+        "www.google.ru/products",
+        "www.google.rw/products",
+        "www.google.sc/products",
+        "www.google.se/products",
+        "www.google.sh/products",
+        "www.google.si/products",
+        "www.google.sk/products",
+        "www.google.sm/products",
+        "www.google.sn/products",
+        "www.google.so/products",
+        "www.google.st/products",
+        "www.google.td/products",
+        "www.google.tg/products",
+        "www.google.tk/products",
+        "www.google.tl/products",
+        "www.google.tm/products",
+        "www.google.to/products",
+        "www.google.tt/products",
+        "www.google.us/products",
+        "www.google.vg/products",
+        "www.google.vu/products",
+        "www.google.ws/products"
+      ]
     },
-    "T-Online": {
-      "domains": ["suche.t-online.de", "brisbane.t-online.de", "navigationshilfe.t-online.de"],
-      "parameters": ["q"]
+    "Google Video": {
+      "parameters": ["q"],
+      "domains": ["video.google.com"]
     },
-    "Sogou": {
-      "domains": ["www.sougou.com", "www.soso.com"],
-      "parameters": ["query", "w"]
+    "Goyellow.de": {
+      "parameters": ["MDN"],
+      "domains": ["www.goyellow.de"]
+    },
+    "Gule Sider": {
+      "parameters": ["q"],
+      "domains": ["www.gulesider.no"]
+    },
+    "HighBeam": {
+      "parameters": ["q"],
+      "domains": ["www.highbeam.com"]
     },
     "Hit-Parade": {
-      "domains": ["req.-hit-parade.com", "class.hit-parade.com", "www.hit-parade.com"],
-      "parameters": ["p7"]
+      "parameters": ["p7"],
+      "domains": ["req.-hit-parade.com", "class.hit-parade.com", "www.hit-parade.com"]
     },
-    "SearchCanvas": {
-      "domains": ["www.searchcanvas.com"],
-      "parameters": ["q"]
+    "Holmes": {
+      "parameters": ["q"],
+      "domains": ["holmes.ge"]
     },
-    "Jungle Key": {
-      "domains": ["junglekey.com", "junglekey.fr"],
-      "parameters": ["query"]
+    "Hooseek.com": {
+      "parameters": ["recherche"],
+      "domains": ["www.hooseek.com"]
     },
-    "Interia": {
-      "domains": ["www.google.interia.pl"],
-      "parameters": ["q"]
+    "Hotbot": {
+      "parameters": ["query"],
+      "domains": ["www.hotbot.com"]
     },
-    "Genieo": {
-      "domains": ["search.genieo.com"],
-      "parameters": ["q"]
+    "Icerockeet": {
+      "parameters": ["q"],
+      "domains": ["blogs.icerocket.com"]
     },
-    "Tiscali": {
-      "domains": ["search.tiscali.it", "search-dyn.tiscali.it", "hledani.tiscali.cz"],
-      "parameters": ["q", "key"]
+    "ICQ": {
+      "parameters": ["q"],
+      "domains": ["www.icq.com", "search.icq.com"]
     },
-    "Gomeo": {
-      "domains": ["www.gomeo.com"],
-      "parameters": ["Keywords"]
-    }
-  },
-  "email": {
-    "Bigpond": {
-      "domains": [
-        "webmail.bigpond.com",
-        "webmail2.bigpond.com",
-        "email.telstra.com",
-        "basic.messaging.bigpond.com"
-      ]
-    },
-    "Naver Mail": {
-      "domains": ["mail.naver.com"]
-    },
-    "Zoho": {
-      "domains": ["mail.zoho.com"]
-    },
-    "Virgin": {
-      "domains": ["webmail.virginbroadband.com.au"]
-    },
-    "Yahoo! Mail": {
-      "domains": [
-        "mail.yahoo.net",
-        "mail.yahoo.com",
-        "mail.yahoo.co.uk",
-        "mail.yahoo.co.jp",
-        "com.yahoo.mobile.client.android.mail"
-      ]
-    },
-    "iiNet": {
-      "domains": ["webmail.iinet.net.au", "mail.iinet.net.au"]
-    },
-    "E1.ru": {
-      "domains": ["mail.e1.ru"]
-    },
-    "Vodafone": {
-      "domains": ["webmail.vodafone.co.nz"]
-    },
-    "126 Mail": {
-      "domains": ["mail.126.com"]
-    },
-    "Mailchimp": {
-      "domains": ["com.mailchimp.mailchimp"]
+    "Ilse": {
+      "parameters": ["search_for"],
+      "domains": ["www.ilse.nl"]
     },
     "Inbox.com": {
-      "domains": ["inbox.com"]
+      "parameters": ["q"],
+      "domains": ["inbox.com/search/"]
     },
-    "iPrimus": {
-      "domains": ["webmail.iprimus.com.au"]
-    },
-    "QQ Mail": {
-      "domains": ["mail.qq.com", "exmail.qq.com"]
-    },
-    "QIP": {
-      "domains": ["mail.qip.ru"]
-    },
-    "Sibmail": {
-      "domains": ["sibmail.com"]
-    },
-    "Freenet": {
-      "domains": ["webmail.freenet.de"]
-    },
-    "Seznam Mail": {
-      "domains": ["email.seznam.cz"]
-    },
-    "Westnet": {
-      "domains": ["webmail.westnet.com.au"]
-    },
-    "Outlook.com": {
-      "domains": ["mail.live.com", "outlook.live.com", "com.microsoft.office.outlook"]
-    },
-    "Dodo": {
-      "domains": ["webmail.dodo.com.au"]
-    },
-    "2degrees": {
-      "domains": ["webmail.2degreesbroadband.co.nz"]
-    },
-    "Daum Mail": {
-      "domains": ["mail2.daum.net", "mail.daum.net"]
-    },
-    "Beeline": {
-      "domains": ["post.ru"]
-    },
-    "Mail.ru": {
-      "domains": ["e.mail.ru", "touch.mail.ru"]
-    },
-    "Adam Internet": {
-      "domains": ["webmail.adam.com.au"]
-    },
-    "Orange Webmail": {
-      "domains": ["orange.fr/webmail"]
-    },
-    "earthlink": {
-      "domains": ["com.earthlink.myearthlink"]
-    },
-    "AOL Mail": {
-      "domains": ["mail.aol.com", "com.aol.mobile.aolapp"]
-    },
-    "Netspace": {
-      "domains": ["webmail.netspace.net.au"]
-    },
-    "Optus Zoo": {
-      "domains": ["webmail.optuszoo.com.au", "webmail.optusnet.com.au"]
-    },
-    "Commander": {
-      "domains": ["webmail.commander.net.au"]
-    },
-    "Mastermail": {
-      "domains": ["mastermail.ru", "m.mastermail.ru"]
-    },
-    "Yandex": {
+    "Indeed": {
       "domains": [
-        "mail.yandex.ru",
-        "mail.yandex.com",
-        "mail.yandex.kz",
-        "mail.yandex.ua",
-        "mail.yandex.by"
+        "de.indeed.com",
+        "at.indeed.com",
+        "fr.indeed.com",
+        "it.indeed.com",
+        "ch.indeed.com",
+        "au.indeed.com"
       ]
     },
-    "163 Mail": {
-      "domains": ["mail.163.com"]
+    "InfoSpace": {
+      "parameters": ["q", "s"],
+      "domains": [
+        "infospace.com",
+        "dogpile.com",
+        "www.dogpile.com",
+        "metacrawler.com",
+        "webfetch.com",
+        "webcrawler.com",
+        "search.kiwee.com",
+        "isearch.babylon.com",
+        "start.facemoods.com",
+        "search.magnetic.com",
+        "search.searchcompletion.com",
+        "clusty.com"
+      ]
     },
-    "Ukr.net": {
-      "domains": ["mail.ukr.net"]
+    "Flyingbird": {
+      "parameters": ["q"],
+      "domains": ["inspsearch.com", "viview.inspsearch.com"]
+    },
+    "Interia": {
+      "parameters": ["q"],
+      "domains": ["www.google.interia.pl"]
+    },
+    "I-play": {
+      "parameters": ["q"],
+      "domains": ["start.iplay.com"]
+    },
+    "I.ua": {
+      "parameters": ["q"],
+      "domains": ["search.i.ua"]
+    },
+    "IXquick": {
+      "parameters": ["query"],
+      "domains": [
+        "ixquick.com",
+        "www.eu.ixquick.com",
+        "ixquick.de",
+        "www.ixquick.de",
+        "us.ixquick.com",
+        "s1.us.ixquick.com",
+        "s2.us.ixquick.com",
+        "s3.us.ixquick.com",
+        "s4.us.ixquick.com",
+        "s5.us.ixquick.com",
+        "eu.ixquick.com",
+        "s8-eu.ixquick.com",
+        "s1-eu.ixquick.de"
+      ]
+    },
+    "Jyxo": {
+      "parameters": ["q"],
+      "domains": ["jyxo.1188.cz"]
+    },
+    "Jungle Spider": {
+      "parameters": ["q"],
+      "domains": ["www.jungle-spider.de"]
+    },
+    "Jungle Key": {
+      "parameters": ["query"],
+      "domains": ["junglekey.com", "junglekey.fr"]
+    },
+    "Kataweb": {
+      "parameters": ["q"],
+      "domains": ["www.kataweb.it"]
+    },
+    "Kvasir": {
+      "parameters": ["q"],
+      "domains": ["www.kvasir.no"]
+    },
+    "kununu": {
+      "parameters": ["q"],
+      "domains": ["kununu.com"]
+    },
+    "Latne": {
+      "parameters": ["q"],
+      "domains": ["www.latne.lv"]
+    },
+    "La Toile Du Quebec Via Google": {
+      "parameters": ["q"],
+      "domains": ["www.toile.com", "web.toile.com"]
+    },
+    "Lilo": {
+      "parameters": ["q"],
+      "domains": ["search.lilo.org"]
+    },
+    "Liveinternet": {
+      "parameters": ["q"],
+      "domains": ["liveinternet.ru"]
+    },
+    "Looksmart": {
+      "parameters": ["key"],
+      "domains": ["www.looksmart.com"]
+    },
+    "Lo.st": {
+      "parameters": ["x_query"],
+      "domains": ["lo.st"]
+    },
+    "Lycos": {
+      "parameters": ["query"],
+      "domains": ["search.lycos.com", "www.lycos.com", "lycos.com"]
+    },
+    "maailm": {
+      "parameters": ["tekst"],
+      "domains": ["www.maailm.com"]
+    },
+    "Mail.ru": {
+      "parameters": ["q"],
+      "domains": ["mail.ru", "m.mail.ru", "go.mail.ru"]
+    },
+    "Mamma": {
+      "parameters": ["query"],
+      "domains": ["www.mamma.com", "mamma75.mamma.com"]
+    },
+    "Marktplaats": {
+      "parameters": ["query"],
+      "domains": ["www.marktplaats.nl"]
+    },
+    "Maxwebsearch": {
+      "parameters": ["query"],
+      "domains": ["maxwebsearch.com"]
+    },
+    "Meta.ua": {
+      "parameters": ["q"],
+      "domains": ["meta.ua"]
+    },
+    "MetaCrawler.de": {
+      "parameters": ["qry"],
+      "domains": ["s1.metacrawler.de", "s2.metacrawler.de", "s3.metacrawler.de"]
+    },
+    "Metager": {
+      "parameters": ["eingabe"],
+      "domains": ["meta.rrzn.uni-hannover.de", "www.metager.de"]
+    },
+    "Metager2": {
+      "parameters": ["q"],
+      "domains": ["metager2.de"]
+    },
+    "Meinestadt": {
+      "parameters": ["words"],
+      "domains": ["www.meinestadt.de"]
+    },
+    "Mister Wong": {
+      "parameters": ["Keywords"],
+      "domains": ["www.mister-wong.com", "www.mister-wong.de"]
+    },
+    "Monster": {
+      "parameters": ["q"],
+      "domains": [
+        "www.monster.be",
+        "www.monster.cz",
+        "www.monster.de",
+        "www.monster.fi",
+        "www.monster.fr",
+        "www.monster.ie",
+        "www.monster.it",
+        "www.monster.lu",
+        "www.monster.ch",
+        "www.monster.co.uk"
+      ]
+    },
+    "Monstercrawler": {
+      "parameters": ["qry"],
+      "domains": ["www.monstercrawler.com"]
+    },
+    "Mozbot": {
+      "parameters": ["q"],
+      "domains": ["www.mozbot.fr", "www.mozbot.co.uk", "www.mozbot.com"]
+    },
+    "El Mundo": {
+      "parameters": ["q"],
+      "domains": ["ariadna.elmundo.es"]
+    },
+    "MySearch": {
+      "parameters": ["searchfor", "searchFor"],
+      "domains": [
+        "mysearch.com",
+        "www.mysearch.com",
+        "ms114.mysearch.com",
+        "ms146.mysearch.com",
+        "kf.mysearch.myway.com",
+        "ki.mysearch.myway.com",
+        "search.myway.com",
+        "search.mywebsearch.com"
+      ]
+    },
+    "Najdi": {
+      "parameters": ["q"],
+      "domains": ["www.najdi.si"]
+    },
+    "Nate": {
+      "parameters": ["q"],
+      "domains": ["search.nate.com"]
+    },
+    "Naver": {
+      "parameters": ["query"],
+      "domains": ["search.naver.com"]
+    },
+    "Naver Images": {
+      "parameters": ["query"],
+      "domains": ["image.search.naver.com", "imagesearch.naver.com"]
+    },
+    "Needtofind": {
+      "parameters": ["searchfor"],
+      "domains": ["ko.search.need2find.com"]
+    },
+    "Neti": {
+      "parameters": ["query"],
+      "domains": ["www.neti.ee"]
+    },
+    "Nifty": {
+      "parameters": ["q"],
+      "domains": ["search.nifty.com"]
+    },
+    "Nigma": {
+      "parameters": ["s"],
+      "domains": ["nigma.ru"]
+    },
+    "Onet": {
+      "parameters": ["qt"],
+      "domains": ["szukaj.onet.pl"]
+    },
+    "Online.no": {
+      "parameters": ["q"],
+      "domains": ["online.no"]
+    },
+    "Opplysningen 1881": {
+      "parameters": ["Query"],
+      "domains": ["www.1881.no"]
+    },
+    "Orange": {
+      "parameters": ["q", "kw"],
+      "domains": ["busca.orange.es", "search.orange.co.uk", "lemoteur.orange.fr"]
+    },
+    "Paperball": {
+      "parameters": ["q"],
+      "domains": ["www.paperball.de"]
+    },
+    "PeoplePC": {
+      "parameters": ["q"],
+      "domains": ["search.peoplepc.com"]
+    },
+    "Picsearch": {
+      "parameters": ["q"],
+      "domains": ["www.picsearch.com"]
+    },
+    "Plazoo": {
+      "parameters": ["q"],
+      "domains": ["www.plazoo.com"]
+    },
+    "Poisk.ru": {
+      "parameters": ["q"],
+      "domains": ["poisk.ru"]
+    },
+    "PriceRunner": {
+      "parameters": ["q"],
+      "domains": ["www.pricerunner.co.uk"]
+    },
+    "qip": {
+      "parameters": ["query"],
+      "domains": ["search.qip.ru"]
+    },
+    "Qualigo": {
+      "parameters": ["q"],
+      "domains": ["www.qualigo.at", "www.qualigo.ch", "www.qualigo.de", "www.qualigo.nl"]
+    },
+    "Qwant": {
+      "parameters": ["q"],
+      "domains": ["www.qwant.com", "lite.qwant.com"]
+    },
+    "Rakuten": {
+      "parameters": ["qt"],
+      "domains": ["websearch.rakuten.co.jp"]
     },
     "Rambler": {
-      "domains": ["mail.rambler.ru"]
+      "parameters": [],
+      "domains": ["nova.rambler.ru"]
     },
-    "Mynet Mail": {
-      "domains": ["mail.mynet.com"]
+    "RPMFind": {
+      "parameters": ["query"],
+      "domains": ["rpmfind.net", "fr2.rpmfind.net"]
     },
-    "Gmail": {
-      "domains": ["mail.google.com", "com.google.android.gm", "inbox.google.com"]
+    "Road Runner Search": {
+      "parameters": ["q"],
+      "domains": ["search.rr.com"]
+    },
+    "Sapo": {
+      "parameters": ["q"],
+      "domains": ["pesquisa.sapo.pt"]
+    },
+    "Search This": {
+      "parameters": ["q"],
+      "domains": ["www.searchthis.com"]
+    },
+    "Search.com": {
+      "parameters": ["q"],
+      "domains": ["www.search.com"]
+    },
+    "Search.ch": {
+      "parameters": ["q"],
+      "domains": ["www.search.ch"]
+    },
+    "Searchalot": {
+      "parameters": ["q"],
+      "domains": ["searchalot.com"]
+    },
+    "SearchCanvas": {
+      "parameters": ["q"],
+      "domains": ["www.searchcanvas.com"]
+    },
+    "Searchy": {
+      "parameters": ["q"],
+      "domains": ["www.searchy.co.uk"]
+    },
+    "Seznam": {
+      "parameters": ["q"],
+      "domains": ["search.seznam.cz"]
+    },
+    "Sharelook": {
+      "parameters": ["keyword"],
+      "domains": ["www.sharelook.fr"]
+    },
+    "Skynet": {
+      "parameters": ["q"],
+      "domains": ["www.skynet.be"]
+    },
+    "The Smart Search": {
+      "parameters": ["q"],
+      "domains": ["thesmartsearch.net", "www.thesmartsearch.net"]
+    },
+    "Sogou": {
+      "parameters": ["query", "w"],
+      "domains": ["www.sougou.com", "www.soso.com"]
+    },
+    "Softonic": {
+      "parameters": ["q"],
+      "domains": ["search.softonic.com"]
+    },
+    "SoSoDesk": {
+      "parameters": ["q"],
+      "domains": ["sosodesktop.com", "search.sosodesktop.com"]
+    },
+    "Shenma": {
+      "parameters": ["q"],
+      "domains": [
+        "so.m.sm.cn",
+        "yz.m.sm.cn",
+        "m.sm.cn",
+        "quark.sm.cn",
+        "m.sp.sm.cn",
+        "m.yz2.sm.cn",
+        "m.yz.sm.cn"
+      ]
+    },
+    "Snapdo": {
+      "parameters": ["q"],
+      "domains": ["search.snapdo.com"]
+    },
+    "Startpagina": {
+      "parameters": ["q"],
+      "domains": ["startgoogle.startpagina.nl"]
+    },
+    "Startsiden": {
+      "parameters": ["q"],
+      "domains": ["www.startsiden.no"]
+    },
+    "StepStone": {
+      "domains": [
+        "www.stepstone.de",
+        "www.stepstone.at",
+        "www.stepstone.be",
+        "www.stepstone.fr",
+        "www.stepstone.nl",
+        "www.stepstone.dk",
+        "www.stepstone.se"
+      ]
+    },
+    "suche.info": {
+      "parameters": ["q"],
+      "domains": ["suche.info"]
+    },
+    "Suchmaschine.com": {
+      "parameters": ["suchstr"],
+      "domains": ["www.suchmaschine.com"]
+    },
+    "Suchnase": {
+      "parameters": ["q"],
+      "domains": ["www.suchnase.de"]
+    },
+    "TalkTalk": {
+      "parameters": ["query"],
+      "domains": ["www.talktalk.co.uk"]
+    },
+    "Technorati": {
+      "parameters": ["q"],
+      "domains": ["technorati.com"]
+    },
+    "Telstra": {
+      "parameters": ["find"],
+      "domains": ["search.media.telstra.com.au"]
+    },
+    "Teoma": {
+      "parameters": ["q"],
+      "domains": ["www.teoma.com"]
+    },
+    "Terra": {
+      "parameters": ["query"],
+      "domains": ["buscador.terra.es", "buscador.terra.cl", "buscador.terra.com.br"]
+    },
+    "Tiscali": {
+      "parameters": ["q", "key"],
+      "domains": ["search.tiscali.it", "search-dyn.tiscali.it", "hledani.tiscali.cz"]
+    },
+    "Tixuma": {
+      "parameters": ["sc"],
+      "domains": ["www.tixuma.de"]
+    },
+    "T-Online": {
+      "parameters": ["q"],
+      "domains": ["suche.t-online.de", "brisbane.t-online.de", "navigationshilfe.t-online.de"]
+    },
+    "Toolbarhome": {
+      "parameters": ["q"],
+      "domains": ["www.toolbarhome.com", "vshare.toolbarhome.com"]
+    },
+    "Trouvez.com": {
+      "parameters": ["query"],
+      "domains": ["www.trouvez.com"]
+    },
+    "TrovaRapido": {
+      "parameters": ["q"],
+      "domains": ["www.trovarapido.com"]
+    },
+    "Trusted-Search": {
+      "parameters": ["w"],
+      "domains": ["www.trusted--search.com"]
+    },
+    "Tut.by": {
+      "parameters": ["query"],
+      "domains": ["search.tut.by"]
+    },
+    "Twingly": {
+      "parameters": ["q"],
+      "domains": ["www.twingly.com"]
+    },
+    "UKR.net": {
+      "parameters": ["q"],
+      "domains": ["search.ukr.net"]
+    },
+    "uol.com.br": {
+      "parameters": ["q"],
+      "domains": ["busca.uol.com.br"]
+    },
+    "URL.ORGanizier": {
+      "parameters": ["q"],
+      "domains": ["www.url.org"]
+    },
+    "Vinden": {
+      "parameters": ["q"],
+      "domains": ["www.vinden.nl"]
+    },
+    "Vindex": {
+      "parameters": ["search_for"],
+      "domains": ["www.vindex.nl", "search.vindex.nl"]
+    },
+    "Virgilio": {
+      "parameters": ["qs"],
+      "domains": [
+        "ricerca.virgilio.it",
+        "ricercaimmagini.virgilio.it",
+        "ricercavideo.virgilio.it",
+        "ricercanews.virgilio.it",
+        "mobile.virgilio.it"
+      ]
+    },
+    "Voila": {
+      "parameters": ["rdata", "kw"],
+      "domains": ["search.ke.voila.fr", "www.lemoteur.fr"]
+    },
+    "Volny": {
+      "parameters": ["search"],
+      "domains": ["web.volny.cz"]
+    },
+    "Walhello ": {
+      "parameters": ["key"],
+      "domains": ["www.walhello.info", "www.walhello.com", "www.walhello.de", "www.walhello.nl"]
+    },
+    "Web.de": {
+      "parameters": ["su"],
+      "domains": ["suche.web.de"]
+    },
+    "Web.nl": {
+      "parameters": ["zoekwoord"],
+      "domains": ["www.web.nl"]
+    },
+    "Weborama": {
+      "parameters": ["QUERY"],
+      "domains": ["www.weborama.com"]
+    },
+    "WebSearch": {
+      "parameters": ["qkw", "q"],
+      "domains": ["www.websearch.com"]
+    },
+    "Winamp": {
+      "parameters": ["q"],
+      "domains": ["search.winamp.com"]
+    },
+    "Witch": {
+      "parameters": ["search"],
+      "domains": ["www.witch.de"]
+    },
+    "Wirtualna Polska": {
+      "parameters": ["szukaj"],
+      "domains": ["szukaj.wp.pl"]
+    },
+    "WWW": {
+      "parameters": ["query"],
+      "domains": ["search.www.ee"]
+    },
+    "X-recherche": {
+      "parameters": ["MOTS"],
+      "domains": ["www.x-recherche.com"]
+    },
+    "Yahoo!": {
+      "parameters": ["p", "q"],
+      "domains": [
+        "search.yahoo.com",
+        "yahoo.com",
+        "ar.search.yahoo.com",
+        "ar.yahoo.com",
+        "au.search.yahoo.com",
+        "au.yahoo.com",
+        "br.search.yahoo.com",
+        "br.yahoo.com",
+        "ca.search.yahoo.com",
+        "ca.yahoo.com",
+        "cade.searchde.yahoo.com",
+        "cade.yahoo.com",
+        "chinese.searchinese.yahoo.com",
+        "chinese.yahoo.com",
+        "cn.search.yahoo.com",
+        "cn.yahoo.com",
+        "de.search.yahoo.com",
+        "de.yahoo.com",
+        "dk.search.yahoo.com",
+        "dk.yahoo.com",
+        "es.search.yahoo.com",
+        "es.yahoo.com",
+        "espanol.searchpanol.yahoo.com",
+        "espanol.yahoo.com",
+        "fr.search.yahoo.com",
+        "fr.yahoo.com",
+        "hk.search.yahoo.com",
+        "hk.yahoo.com",
+        "ie.search.yahoo.com",
+        "ie.yahoo.com",
+        "in.search.yahoo.com",
+        "in.yahoo.com",
+        "it.search.yahoo.com",
+        "it.yahoo.com",
+        "kr.search.yahoo.com",
+        "kr.yahoo.com",
+        "mx.search.yahoo.com",
+        "mx.yahoo.com",
+        "no.search.yahoo.com",
+        "no.yahoo.com",
+        "nz.search.yahoo.com",
+        "nz.yahoo.com",
+        "one.cn.yahoo.com",
+        "one.searchn.yahoo.com",
+        "qc.search.yahoo.com",
+        "qc.yahoo.com",
+        "ru.search.yahoo.com",
+        "ru.yahoo.com",
+        "se.search.yahoo.com",
+        "se.yahoo.com",
+        "search.searcharch.yahoo.com",
+        "tw.search.yahoo.com",
+        "tw.yahoo.com",
+        "uk.search.yahoo.com",
+        "uk.yahoo.com",
+        "us.search.yahoo.com",
+        "us.yahoo.com",
+        "www.yahoo.co.jp",
+        "search.yahoo.co.jp",
+        "www.cercato.it",
+        "search.offerbox.com",
+        "ys.mirostart.com"
+      ]
+    },
+    "Yahoo! Images": {
+      "parameters": ["p", "q"],
+      "domains": ["image.yahoo.cn", "images.search.yahoo.com"]
+    },
+    "Yam": {
+      "parameters": ["k"],
+      "domains": ["search.yam.com"]
+    },
+    "Yandex": {
+      "parameters": ["text"],
+      "domains": [
+        "yandex.ru",
+        "yandex.ua",
+        "yandex.com",
+        "yandex.by",
+        "www.yandex.ru",
+        "www.yandex.ua",
+        "www.yandex.com",
+        "www.yandex.by",
+        "clck.yandex.ru",
+        "clck.yandex.ua",
+        "clck.yandex.com",
+        "clck.yandex.by"
+      ]
+    },
+    "Yandex Images": {
+      "parameters": ["text"],
+      "domains": ["images.yandex.ru", "images.yandex.ua", "images.yandex.com", "images.yandex.by"]
+    },
+    "Yasni": {
+      "parameters": ["query"],
+      "domains": [
+        "www.yasni.de",
+        "www.yasni.com",
+        "www.yasni.co.uk",
+        "www.yasni.ch",
+        "www.yasni.at"
+      ]
+    },
+    "Yatedo": {
+      "parameters": ["q"],
+      "domains": ["www.yatedo.com", "www.yatedo.fr"]
+    },
+    "Yippy": {
+      "parameters": ["q", "query"],
+      "domains": ["search.yippy.com"]
+    },
+    "YouGoo": {
+      "parameters": ["q"],
+      "domains": ["www.yougoo.fr"]
+    },
+    "Zapmeta": {
+      "parameters": ["q", "query"],
+      "domains": ["www.zapmeta.com", "www.zapmeta.nl", "www.zapmeta.de", "uk.zapmeta.com"]
+    },
+    "Zoek": {
+      "parameters": ["q"],
+      "domains": ["www3.zoek.nl"]
+    },
+    "Zhongsou": {
+      "parameters": ["w"],
+      "domains": ["p.zhongsou.com"]
+    },
+    "Zoeken": {
+      "parameters": ["q"],
+      "domains": ["www.zoeken.nl"]
+    },
+    "Zoohoo": {
+      "parameters": ["q"],
+      "domains": ["zoohoo.cz"]
     }
   },
   "paid": {
+    "Acuity Ads": {
+      "domains": ["acuityplatform.com"]
+    },
+    "Adform": {
+      "domains": ["adform.net"]
+    },
+    "ADFOX": {
+      "domains": ["adfox.ru", "www.adfox.ru", "ads.adfox.ru", "www.ads.adfox.ru"]
+    },
+    "Adition": {
+      "domains": ["adition.com"]
+    },
+    "AdNET": {
+      "domains": ["adnet.de"]
+    },
+    "AdRoll": {
+      "domains": ["adroll.com"]
+    },
     "AdSpirit": {
       "domains": ["adspirit.de", "rtbcity.com", "plusperformance.com"]
     },
-    "Flashtalking": {
-      "domains": ["flashtalking.com", "servedby.flashtalking.com"]
+    "AppNexus": {
+      "domains": ["ib.adnxs.com", "adnxs.com", "247realmedia.com"]
     },
     "AudienceScience": {
       "domains": ["wunderloop.net"]
     },
-    "Outbrain": {
-      "domains": ["paid.outbrain.com"]
+    "BidSwitch": {
+      "domains": ["bidswitch.net"]
     },
-    "Yieldmo": {
-      "domains": ["yieldmo.com"]
+    "Casale Media": {
+      "domains": ["casalemedia.com"]
     },
-    "Mozo": {
-      "domains": ["mozo.com.au", "a.mozo.com.au"]
-    },
-    "Acuity Ads": {
-      "domains": ["acuityplatform.com"]
-    },
-    "LifeStreet": {
-      "domains": ["lfstmedia.com"]
-    },
-    "MicroAd": {
-      "domains": ["microad.jp"]
-    },
-    "Taboola": {
-      "domains": ["trc.taboola.com", "api.taboola.com", "taboola.com"]
+    "Criteo": {
+      "domains": ["cas.jp.as.criteo.com", "cas.criteo.com"]
     },
     "Doubleclick": {
       "domains": [
@@ -3007,24 +3425,48 @@
         "pubads.g.doubleclick.net"
       ]
     },
-    "Adform": {
-      "domains": ["adform.net"]
+    "Eyeota": {
+      "domains": ["eyeota.net"]
     },
-    "Sizmek": {
-      "domains": ["bs.serving-sys.com"]
-    },
-    "Criteo": {
-      "domains": ["cas.jp.as.criteo.com", "cas.criteo.com"]
+    "Flashtalking": {
+      "domains": ["flashtalking.com", "servedby.flashtalking.com"]
     },
     "Fluct": {
       "domains": ["adingo.jp"]
     },
-    "LowerMyBills": {
-      "domains": ["lowermybills.com"],
-      "parameters": ["leadid"]
+    "Google": {
+      "domains": [
+        "www.googleadservices.com",
+        "partner.googleadservices.com",
+        "googleads.g.doubleclick.net",
+        "tdsf.doubleclick.net",
+        "tpc.googlesyndication.com",
+        "safeframe.googlesyndication.com",
+        "googleadservices.com",
+        "imasdk.googleapis.com",
+        "www.adsensecustomsearchads.com",
+        "syndicatedsearch.goog",
+        "pagead2.googlesyndication.com"
+      ]
     },
-    "White Pages": {
-      "domains": ["www.whitepages.com.au", "mobile.whitepages.com.au"]
+    "LifeStreet": {
+      "domains": ["lfstmedia.com"]
+    },
+    "LowerMyBills": {
+      "parameters": ["leadid"],
+      "domains": ["lowermybills.com"]
+    },
+    "Jivox": {
+      "domains": ["jivox.com"]
+    },
+    "MicroAd": {
+      "domains": ["microad.jp"]
+    },
+    "Mixpo": {
+      "domains": ["mixpo.com"]
+    },
+    "Mozo": {
+      "domains": ["mozo.com.au", "a.mozo.com.au"]
     },
     "Neustar AdAdvisor": {
       "domains": ["adadvisor.net"]
@@ -3032,78 +3474,53 @@
     "ONE by AOL": {
       "domains": ["nexage.com"]
     },
-    "Mixpo": {
-      "domains": ["mixpo.com"]
+    "OpenX": {
+      "domains": ["us-ads.openx.net", "openx.net", "servedbyopenx.com", "openxenterprise.com"]
     },
-    "Rubicon Project": {
-      "domains": ["optimized-by.rubiconproject.com"]
-    },
-    "PubMatic": {
-      "domains": ["sshowads.pubmatic.com"]
-    },
-    "Jivox": {
-      "domains": ["jivox.com"]
-    },
-    "BidSwitch": {
-      "domains": ["bidswitch.net"]
-    },
-    "Sonobi": {
-      "domains": ["sonobi.com"]
-    },
-    "SteelHouse": {
-      "domains": ["steelhousemedia.com"]
-    },
-    "AdRoll": {
-      "domains": ["adroll.com"]
-    },
-    "AdNET": {
-      "domains": ["adnet.de"]
-    },
-    "Tribal Fusion": {
-      "domains": ["cdnx.tribalfusion.com"]
-    },
-    "Yandex.Market": {
-      "domains": ["market.yandex.ru", "m.market.yandex.ru"]
-    },
-    "StickyADS.tv": {
-      "domains": ["stickyadstv.com", "sfx.stickyadstv.com"]
-    },
-    "ZEDO": {
-      "domains": ["zedo.com", "z1.zedo.com"]
+    "Outbrain": {
+      "domains": ["paid.outbrain.com"]
     },
     "Plista": {
       "domains": ["farm.plista.com"]
     },
-    "AppNexus": {
-      "domains": ["ib.adnxs.com", "adnxs.com", "247realmedia.com"]
+    "Price.ru": {
+      "domains": ["price.ru", "v.price.ru"]
+    },
+    "PubMatic": {
+      "domains": ["sshowads.pubmatic.com"]
+    },
+    "Rubicon Project": {
+      "domains": ["optimized-by.rubiconproject.com"]
+    },
+    "Sizmek": {
+      "domains": ["bs.serving-sys.com"]
+    },
+    "Sociomantic Labs": {
+      "domains": ["sociomantic.com"]
+    },
+    "Sonobi": {
+      "domains": ["sonobi.com"]
     },
     "Sovrn": {
       "domains": ["lijit.com"]
     },
-    "Google": {
-      "domains": [
-        "www.googleadservices.com",
-        "partner.googleadservices.com",
-        "googleads.g.doubleclick.net",
-        "tpc.googlesyndication.com",
-        "googleadservices.com",
-        "imasdk.googleapis.com"
-      ]
+    "SteelHouse": {
+      "domains": ["steelhousemedia.com"]
     },
-    "Eyeota": {
-      "domains": ["eyeota.net"]
+    "StickyADS.tv": {
+      "domains": ["stickyadstv.com", "sfx.stickyadstv.com"]
     },
-    "Price.ru": {
-      "domains": ["price.ru", "v.price.ru"]
+    "Taboola": {
+      "domains": ["trc.taboola.com", "api.taboola.com", "taboola.com"]
     },
-    "OpenX": {
-      "domains": ["us-ads.openx.net", "openx.net", "servedbyopenx.com", "openxenterprise.com"]
+    "Torg.Mail.ru": {
+      "domains": ["torg.mail.ru"]
     },
-    "Casale Media": {
-      "domains": ["casalemedia.com"]
+    "Tribal Fusion": {
+      "domains": ["cdnx.tribalfusion.com"]
     },
-    "Adition": {
-      "domains": ["adition.com"]
+    "White Pages": {
+      "domains": ["www.whitepages.com.au", "mobile.whitepages.com.au"]
     },
     "Yandex.Direct": {
       "domains": [
@@ -3114,319 +3531,85 @@
         "yabs.yandex.by"
       ]
     },
-    "ADFOX": {
-      "domains": ["adfox.ru", "www.adfox.ru", "ads.adfox.ru", "www.ads.adfox.ru"]
+    "Yandex.Market": {
+      "domains": ["market.yandex.ru", "m.market.yandex.ru"]
     },
-    "Torg.Mail.ru": {
-      "domains": ["torg.mail.ru"]
+    "Yieldmo": {
+      "domains": ["yieldmo.com"]
     },
-    "Sociomantic Labs": {
-      "domains": ["sociomantic.com"]
+    "ZEDO": {
+      "domains": ["zedo.com", "z1.zedo.com"]
     }
   },
-  "social": {
-    "hi5": {
-      "domains": ["hi5.com"]
+  "chatbot": {
+    "Character.AI": {
+      "domains": ["character.ai", "beta.character.ai"]
     },
-    "Friendster": {
-      "domains": ["friendster.com"]
+    "ChatGPT": {
+      "domains": ["chatgpt.com", "chat.openai.com", "labs.openai.com"]
     },
-    "vKruguDruzei.ru": {
-      "domains": ["vkrugudruzei.ru"]
+    "Claude.ai": {
+      "domains": ["claude.ai"]
     },
-    "Xanga": {
-      "domains": ["xanga.com"]
+    "Google Gemini": {
+      "domains": ["gemini.google.com", "bard.google.com"]
     },
-    "Myspace": {
-      "domains": ["myspace.com"]
+    "META.ai": {
+      "domains": ["meta.ai"]
     },
-    "Buzznet": {
-      "domains": ["buzznet.com"]
+    "Microsoft Copilot": {
+      "domains": ["copilot.microsoft.com"]
     },
-    "MyLife": {
-      "domains": ["mylife.ru"]
+    "Mistral.ai": {
+      "domains": ["chat.mistral.ai"]
     },
-    "Flickr": {
-      "domains": ["flickr.com"]
+    "Perplexity.ai": {
+      "domains": ["perplexity.ai"]
     },
-    "Whirlpool": {
-      "domains": ["forums.whirlpool.net.au"]
+    "Poe": {
+      "domains": ["poe.com"]
     },
-    "Sonico.com": {
-      "domains": ["sonico.com"]
+    "Baidu AI": {
+      "domains": ["yiyan.baidu.com", "ai.baidu.com"]
     },
-    "Odnoklassniki": {
-      "domains": ["odnoklassniki.ru", "ok.ru"]
+    "Chat+": {
+      "domains": ["chatplus.com", "chat-gpt.org"]
     },
-    "Tildes": {
-      "domains": ["tildes.net", "com.talklittle.android.tildes"]
+    "ChatGLM": {
+      "domains": ["chatglm.cn"]
     },
-    "Classmates": {
-      "domains": ["classmates.com"]
+    "DeepSeek": {
+      "domains": ["chat.deepseek.com", "deepseek.com"]
     },
-    "Friends Reunited": {
-      "domains": ["friendsreunited.com"]
+    "Grok": {
+      "domains": ["grok.com"]
     },
-    "Hacker News": {
-      "domains": ["news.ycombinator.com", "io.github.hidroh.materialistic"]
+    "iAsk": {
+      "domains": ["iask.ai"]
     },
-    "Quora": {
-      "domains": ["quora.com"]
+    "Jasper": {
+      "domains": ["app.jasper.ai"]
     },
-    "LiveJournal": {
-      "domains": ["livejournal.ru"]
+    "NotebookLM": {
+      "domains": ["notebooklm.google.com"]
     },
-    "Netlog": {
-      "domains": ["netlog.com"]
+    "Qwen": {
+      "domains": ["chat.qwen.ai"]
     },
-    "Orkut": {
-      "domains": ["orkut.com"]
+    "Writesonic": {
+      "domains": ["app.writesonic.com"]
     },
-    "MyHeritage": {
-      "domains": ["myheritage.com"]
+    "You": {
+      "domains": ["you.com"]
     },
-    "Multiply": {
-      "domains": ["multiply.com"]
+    "Phind": {
+      "domains": ["phind.com"]
     },
-    "Threads": {
-      "domains": ["threads.net", "l.threads.net", "com.instagram.barcelona"]
+    "Pi": {
+      "domains": ["pi.ai"]
     },
-    "myYearbook": {
-      "domains": ["myyearbook.com"]
-    },
-    "Renren": {
-      "domains": ["renren.com"]
-    },
-    "Slack": {
-      "domains": ["app.slack.com", "com.slack"]
-    },
-    "WeeWorld": {
-      "domains": ["weeworld.com"]
-    },
-    "Vimeo": {
-      "domains": ["vimeo.com"]
-    },
-    "Eksi Sozluk": {
-      "domains": ["Sozluk.com", "sourtimes.org"]
-    },
-    "Mixi": {
-      "domains": ["mixi.jp"]
-    },
-    "Geni": {
-      "domains": ["geni.com"]
-    },
-    "Uludag Sozluk": {
-      "domains": ["uludagsozluk.com", "ulusozluk.com"]
-    },
-    "SourceForge": {
-      "domains": ["sourceforge.net"]
-    },
-    "Plaxo": {
-      "domains": ["plaxo.com"]
-    },
-    "Taringa!": {
-      "domains": ["taringa.net"]
-    },
-    "Tagged": {
-      "domains": ["login.tagged.com"]
-    },
-    "XING": {
-      "domains": ["xing.com"]
-    },
-    "Instagram": {
-      "domains": ["instagram.com", "l.instagram.com", "com.instagram.android"]
-    },
-    "Vkontakte": {
-      "domains": ["m.vk.com", "vk.com", "away.vk.com", "vkontakte.ru"]
-    },
-    "Weibo": {
-      "domains": ["weibo.com", "t.cn"]
-    },
-    "Telegram": {
-      "domains": [
-        "web.telegram.org",
-        "org.telegram.messenger",
-        "org.telegram.messenger.web",
-        "org.aka.messenger",
-        "org.telegram.biftogram",
-        "org.telegram.plus"
-      ]
-    },
-    "Twitter": {
-      "domains": ["twitter.com", "t.co", "com.twitter.android"]
-    },
-    "Snapchat": {
-      "domains": ["com.snapchat.android", "snapchat.com"]
-    },
-    "Donanimhaber": {
-      "domains": ["donanimhaber.com"]
-    },
-    "WAYN": {
-      "domains": ["wayn.com"]
-    },
-    "Skype": {
-      "domains": ["web.skype.com"]
-    },
-    "Mail.ru": {
-      "domains": ["my.mail.ru"]
-    },
-    "Badoo": {
-      "domains": ["badoo.com"]
-    },
-    "Instela": {
-      "domains": ["instela.com"]
-    },
-    "Habbo": {
-      "domains": ["habbo.com"]
-    },
-    "Pinterest": {
-      "domains": [
-        "pinterest.ca",
-        "pinterest.cl",
-        "pinterest.co.kr",
-        "pinterest.com",
-        "pinterest.com.au",
-        "pinterest.co.uk",
-        "pinterest.de",
-        "pinterest.dk",
-        "pinterest.es",
-        "pinterest.fr",
-        "pinterest.jp",
-        "pinterest.nz",
-        "pinterest.pt",
-        "pinterest.se",
-        "pinterest.at",
-        "pinterest.ch",
-        "pinterest.com.mx",
-        "pinterest.ie",
-        "pinterest.it",
-        "pinterest.ph",
-        "pinterest.ru",
-        "com.pinterest"
-      ]
-    },
-    "LinkedIn": {
-      "domains": ["com.linkedin.android", "linkedin.com", "lnkd.in"]
-    },
-    "Foursquare": {
-      "domains": ["foursquare.com"]
-    },
-    "Douban": {
-      "domains": ["douban.com"]
-    },
-    "Windows Live Spaces": {
-      "domains": ["login.live.com"]
-    },
-    "BlackPlanet": {
-      "domains": ["blackplanet.com"]
-    },
-    "Cyworld": {
-      "domains": ["global.cyworld.com"]
-    },
-    "Pocket": {
-      "domains": ["getpocket.com"]
-    },
-    "Skyrock": {
-      "domains": ["skyrock.com"]
-    },
-    "Facebook": {
-      "domains": [
-        "facebook.com",
-        "fb.me",
-        "m.facebook.com",
-        "l.facebook.com",
-        "lm.facebook.com",
-        "com.facebook.katana"
-      ]
-    },
-    "WhatsApp": {
-      "domains": ["web.whatsapp.com", "com.whatsapp"]
-    },
-    "Disqus": {
-      "domains": ["redirect.disqus.com", "disq.us", "disqus.com"]
-    },
-    "StudiVZ": {
-      "domains": ["studivz.net"]
-    },
-    "Fotolog": {
-      "domains": ["fotolog.com"]
-    },
-    "ITU Sozluk": {
-      "domains": ["itusozluk.com"]
-    },
-    "Google+": {
-      "domains": ["url.google.com", "plus.google.com"]
-    },
-    "Nasza-klasa.pl": {
-      "domains": ["nk.pl"]
-    },
-    "Qzone": {
-      "domains": ["qzone.qq.com"]
-    },
-    "Flixster": {
-      "domains": ["flixster.com"]
-    },
-    "Bebo": {
-      "domains": ["bebo.com"]
-    },
-    "Tuenti": {
-      "domains": ["tuenti.com"]
-    },
-    "Youtube": {
-      "domains": ["youtube.com", "youtu.be"]
-    },
-    "Reddit": {
-      "domains": [
-        "reddit.com",
-        "io.syncapps.lemmy_sync",
-        "com.laurencedawson.reddit_sync",
-        "com.laurencedawson.reddit_sync.pro"
-      ]
-    },
-    "Viadeo": {
-      "domains": ["viadeo.com"]
-    },
-    "GitHub": {
-      "domains": ["github.com"]
-    },
-    "StackOverflow": {
-      "domains": ["stackoverflow.com"]
-    },
-    "Gaia Online": {
-      "domains": ["gaiaonline.com"]
-    },
-    "StumbleUpon": {
-      "domains": ["stumbleupon.com"]
-    },
-    "Inci Sozluk": {
-      "domains": ["inci.sozlukspot.com", "incisozluk.com", "incisozluk.cc"]
-    },
-    "Identi.ca": {
-      "domains": ["identi.ca"]
-    },
-    "Last.fm": {
-      "domains": ["lastfm.ru"]
-    },
-    "Tumblr": {
-      "domains": ["tumblr.com", "t.umblr.com"]
-    },
-    "TikTok": {
-      "domains": ["tiktok.com"]
-    },
-    "Hocam.com": {
-      "domains": ["hocam.com"]
-    },
-    "Delicious": {
-      "domains": ["delicious.com"]
-    },
-    "Hyves": {
-      "domains": ["hyves.nl"]
-    },
-    "Paper.li": {
-      "domains": ["paper.li"]
-    },
-    "MoiKrug.ru": {
-      "domains": ["moikrug.ru"]
+    "HuggingChat": {
+      "domains": ["huggingface.co"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Updates the bundled referer database with 100+ new domains across all categories, most notably adding the entirely new **chatbot/AI** category.

### New chatbot/AI category (23 sources)
ChatGPT, Claude, Perplexity, Google Gemini, Microsoft Copilot, DeepSeek, Grok, Phind, Mistral/Le Chat, Poe, Character.AI, Meta AI, Baidu AI, Chat+, ChatGLM, iAsk, Jasper, NotebookLM, Qwen, Writesonic, You, Pi, HuggingChat

### New social sources
- **Mastodon** (11 major instances)
- **Discord** (`discord.com`, `discordapp.com`)
- **x.com** added to Twitter
- **bsky.app** added to Bluesky
- Additional subdomains for TikTok, Facebook, Reddit

### Updated from upstream
- Snowplow referer-parser (master): +11 email, +3 social, +2 search sources
- Matomo searchengine-and-social-list: additional AI assistants

### Stats
| Category | Before | After |
|----------|--------|-------|
| chatbot | **0** | **23 sources, 30 domains** |
| social | 87 | 92 sources (+Mastodon, Discord, domain additions) |
| search | 236 | 237 sources |
| email | 38 | 47 sources |
| paid | 45 | 45 sources |
| unknown | 3 | 3 sources |

## Test plan

- [x] 35 tests pass (24 existing + 11 new)
- [x] New tests cover: ChatGPT, Claude, Perplexity, Gemini, DeepSeek, Grok, Copilot, Phind, Bluesky, Mastodon, Brave Search
- [x] Build succeeds
- [x] All existing tests still pass (no regressions)